### PR TITLE
Embedded zmq cp into test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,15 +42,10 @@ endif(${CXX_COMPILER_IS_CLANG++})
 # Targets
 ###############################################################################
 
-# Tests
+# Test cases
 file(GLOB TESTS test/*.cpp)
 add_executable(check EXCLUDE_FROM_ALL ${TESTS})
 target_link_libraries(check ${LIBS})
-
-enable_testing()
-add_test(graybat_test_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target check)
-add_test(graybat_test_run mpiexec -n 2 check --run_test=cage_point_to_point)
-SET_TESTS_PROPERTIES (graybat_test_run PROPERTIES DEPENDS graybat_test_build)
 
 # Examples
 add_custom_target(example)
@@ -64,8 +59,14 @@ foreach(EXAMPLE ${EXAMPLES})
 endforeach(EXAMPLE)
 
 # ZMQ signaling server
-add_executable(zmq_signaling_server EXCLUDE_FROM_ALL utils/zmq_signaling_server.cc )
-target_link_libraries(zmq_signaling_server ${LIBS})
+add_executable(zmq_signaling EXCLUDE_FROM_ALL utils/zmq_signaling_server.cpp )
+target_link_libraries(zmq_signaling ${LIBS})
+
+# CTest
+enable_testing()
+add_test(graybat_check_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target check)
+add_test(graybat_test_run  mpiexec -n 2 check )
+set_tests_properties(graybat_test_run PROPERTIES DEPENDS graybat_check_build)
 
 # Doxygen
 find_package(Doxygen)
@@ -75,6 +76,6 @@ if(DOXYGEN_FOUND)
     COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Generating API documentation with Doxygen" VERBATIM
+    COMMENT "Generating API documentation with Doxygen." VERBATIM
     )
 endif(DOXYGEN_FOUND)

--- a/include/graybat/Cage.hpp
+++ b/include/graybat/Cage.hpp
@@ -1,25 +1,22 @@
 #pragma once
 
 // CLIB
-#include <assert.h>   /* assert */
-#include <cstddef>    /* nullptr_t */
+#include <assert.h>  /* assert */
+#include <cstddef>   /* nullptr_t */
 
 // STL
-#include <map>        /* map */
-#include <set>        /* set */
-#include <exception>  /* std::out_of_range */
-#include <sstream>    /* std::stringstream */
-#include <algorithm>  /* std::max */
-#include <stdexcept>  /* std::runtime_error */
-#include <tuple>      /* std::tie */
-#include <sstream>    /* std::sstream */
+#include <map>       /* map */
+#include <exception> /* std::out_of_range */
+#include <algorithm> /* std::max */
+#include <stdexcept> /* std::runtime_error */
+#include <tuple>     /* std::tie */
+#include <memory>    /* std::shared_memory */
 
 // GRAYBAT
-#include <graybat/utils/exclusivePrefixSum.hpp>  /* exclusivePrefixSum */
-#include <graybat/Vertex.hpp> /* CommunicationVertex */
-#include <graybat/Edge.hpp>   /* CommunicationEdge */
-#include <graybat/pattern/None.hpp> /* graybatt::pattern::None */
-
+#include <graybat/utils/exclusivePrefixSum.hpp> /* exclusivePrefixSum */
+#include <graybat/Vertex.hpp>                   /* CommunicationVertex */
+#include <graybat/Edge.hpp>                     /* CommunicationEdge */
+#include <graybat/pattern/None.hpp>             /* graybatt::pattern::None */
 
 namespace graybat {
 
@@ -61,15 +58,19 @@ namespace graybat {
         typedef unsigned Peer;
         
         template <class T_Functor>
-        Cage(T_Functor graphFunctor) : graph(GraphPolicy(graphFunctor())){
+        Cage(CommunicationPolicy& comm, T_Functor graphFunctor) :
+	    comm(comm),
+	    graph(GraphPolicy(graphFunctor())){
 	    
         }
+	
+	Cage(CommunicationPolicy& comm) :
+	    comm(comm),
+	    graph(GraphPolicy(graybat::pattern::None()())){
 
-        Cage() : graph(GraphPolicy(graybat::pattern::None()())){
+	}
 
-        }
-
-	~Cage(){
+ 	~Cage(){
 	    //std::cout << "Destruct Cage" << std::endl;
 	}
 
@@ -79,10 +80,10 @@ namespace graybat {
          * MEMBER
          *
          ***************************************************************************/
-        CommunicationPolicy comm;
-        GraphPolicy         graph;
-        Context             graphContext;
-        std::vector<Vertex> hostedVertices;
+	CommunicationPolicy& comm;
+        GraphPolicy          graph;
+        Context              graphContext;
+        std::vector<Vertex>  hostedVertices;
 
 
         /***************************************************************************

--- a/test/BMPIUT.cpp
+++ b/test/BMPIUT.cpp
@@ -38,14 +38,16 @@ typedef typename Cage::Edge   Edge;
  * Test Cases
  ****************************************************************************/
 
-BOOST_AUTO_TEST_SUITE( cage_point_to_point )
+BOOST_AUTO_TEST_SUITE( bmpi )
 
-Cage allToAll;
-Cage star;
+CP communicationPolicy;
+Cage allToAll(communicationPolicy);
+Cage star(communicationPolicy);
+Cage grid(communicationPolicy);
 
 BOOST_AUTO_TEST_CASE( multi_cage ){
-    Cage cage1;
-    Cage cage2;
+    Cage cage1(communicationPolicy);
+    Cage cage2(communicationPolicy);
 
     cage1.setGraph(graybat::pattern::InStar(cage1.getPeers().size()));
     cage1.distribute(graybat::mapping::Consecutive());
@@ -184,14 +186,6 @@ BOOST_AUTO_TEST_CASE( asyncSend_recv ){
     }
 
 }
-
-
-BOOST_AUTO_TEST_SUITE_END()
-
-BOOST_AUTO_TEST_SUITE( cage_collectives )
-
-Cage grid;
-Cage star;
 
 BOOST_AUTO_TEST_CASE( reduce ){
     grid.setGraph(graybat::pattern::Grid(3,3));

--- a/test/EdgeUT.cpp
+++ b/test/EdgeUT.cpp
@@ -37,7 +37,8 @@ typedef typename Cage::Edge   Edge;
 
 BOOST_AUTO_TEST_SUITE(edge)
 
-Cage grid;
+CP communicationPolicy;
+Cage grid(communicationPolicy);
 
 BOOST_AUTO_TEST_CASE( send_recv){
     std::vector<Event> events;

--- a/test/VertexUT.cpp
+++ b/test/VertexUT.cpp
@@ -37,8 +37,9 @@ typedef typename Cage::Edge   Edge;
 
 BOOST_AUTO_TEST_SUITE(vertex)
 
-Cage grid;
-Cage chain;
+CP communicationPolicy;
+Cage grid(communicationPolicy);
+Cage chain(communicationPolicy);
 
 BOOST_AUTO_TEST_CASE( spread_collect ){
     std::vector<Event> events;

--- a/utils/zmq_env.sh
+++ b/utils/zmq_env.sh
@@ -1,7 +1,7 @@
 #! /bin/fish
 
-set -x GRAYBAT_ZMQ_MASTER_URI          tcp://127.0.0.1:5000
-set -x GRAYBAT_ZMQ_LOCAL_BASE_URI      tcp://127.0.0.1
-set -x GRAYBAT_ZMQ_LOCAL_BASE_PORT     5001
-set -x GRAYBAT_ZMQ_GLOBAL_CONTEXT_SIZE 2
+set -x GRAYBAT_ZMQ_SIGNALING_URI        tcp://127.0.0.1:5000
+set -x GRAYBAT_ZMQ_BASE_PEER_URI        tcp://127.0.0.1
+set -x GRAYBAT_ZMQ_PEER_URI             tcp://127.0.0.1:5001
+set -x GRAYBAT_ZMQ_INITIAL_CONTEXT_SIZE 2
 

--- a/utils/zmq_signaling_server.cpp
+++ b/utils/zmq_signaling_server.cpp
@@ -52,7 +52,7 @@ int main(){
 
     std::map<ContextID, std::map<VAddr, Uri> > phoneBook;
     std::map<ContextID, VAddr> maxVAddr;
-    std::string masterUri = std::getenv("GRAYBAT_ZMQ_MASTER_URI");
+    std::string masterUri = "tcp://127.0.0.1:5000";
     zmq::context_t context(1);
     
     zmq::message_t request;
@@ -67,7 +67,6 @@ int main(){
 
     ContextID maxContextID = 0;
     ContextID maxInitialContextID = maxContextID;    
-    unsigned nPeers = 0;
 
     while(true){
         std::stringstream ss;
@@ -132,7 +131,7 @@ int main(){
                 else {
                     sss << ACK << " " << phoneBook[contextID][remoteVAddr] << " ";
                     s_send(socket, sss.str().c_str());
-		    std::cout << "VADDR LOOKUP [contextID:" << contextID << "][remoteVAddr:" << remoteVAddr << "]:" << phoneBook[contextID][remoteVAddr] << "|" << std::endl;
+		    std::cout << "VADDR LOOKUP [contextID:" << contextID << "][remoteVAddr:" << remoteVAddr << "]: " << phoneBook[contextID][remoteVAddr] << std::endl;
                 }
 
                 break;


### PR DESCRIPTION
ZMQ communication policy can now be tested with `make test`.
The user needs to build and start the signaling server in advance:

```
make zmq_signaling
./zmq_signaling&
make test
```
