### PR TITLE
Added option for signaling port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project("graybat examples and tests")
 ###############################################################################
 # Boost
 ###############################################################################
-find_package(Boost 1.58.0 COMPONENTS unit_test_framework  REQUIRED)
+find_package(Boost 1.58.0 COMPONENTS unit_test_framework program_options REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 include_directories(SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/include/graybat/utils/hana/include/")
 set(LIBS ${LIBS} ${Boost_LIBRARIES})


### PR DESCRIPTION
port to listen for signaling request can be specified by -p or --port
- Fixes #73 
- @fabian-jung  do you want to have a look at this PR ?

A release will follow this pr.
