### PR TITLE
New Filter mapping

### DIFF
--- a/example/anyrecv.cpp
+++ b/example/anyrecv.cpp
@@ -60,7 +60,7 @@ int exp() {
     Cage cage(config);
 
     // Set communication pattern
-    cage.setGraph(graybat::pattern::BiStar(cage.getPeers().size()));
+    cage.setGraph(graybat::pattern::BiStar<GP>(cage.getPeers().size()));
 
     // Distribute vertices
     cage.distribute(graybat::mapping::Consecutive());

--- a/example/chain.cpp
+++ b/example/chain.cpp
@@ -23,8 +23,15 @@
 #include <graybat/mapping/Consecutive.hpp>
 #include <graybat/mapping/Random.hpp>
 #include <graybat/mapping/Roundrobin.hpp>
+#include <graybat/mapping/Filter.hpp>
 // GRAYBAT pattern
 #include <graybat/pattern/Chain.hpp>
+
+
+struct Tag {
+    int tag;
+    
+};
 
 int exp() {
     /***************************************************************************
@@ -36,7 +43,7 @@ int exp() {
     typedef CP::Config                         Config;    
     
     // GraphPolicy
-    typedef graybat::graphPolicy::BGL<>    GP;
+    typedef graybat::graphPolicy::BGL<Tag, Tag>    GP;
     
     // Cage
     typedef graybat::Cage<CP, GP> Cage;
@@ -46,17 +53,17 @@ int exp() {
     /***************************************************************************
      * Initialize Communication
      ****************************************************************************/
-    const unsigned nChainLinks = 1000;
+    const unsigned nChainLinks = 6;
     auto inc = [](unsigned &a){a++;};
 
     // Create GoL Graph
     Config config;
     Cage cage(config);
 
-    cage.setGraph(graybat::pattern::Chain(nChainLinks));
+    cage.setGraph(graybat::pattern::Chain<GP>(nChainLinks));
     
     // Distribute vertices
-    cage.distribute(graybat::mapping::Consecutive());
+    cage.distribute(graybat::mapping::Filter(cage.comm.getGlobalContext().getVAddr() % 3));
 
     /***************************************************************************
      * Run Simulation
@@ -73,29 +80,29 @@ int exp() {
 
     for(Vertex v : cage.hostedVertices){
 
-	if(v == entry){
-	    v.spread(input, events);
-	    std::cout << "Input: " << input[0] << std::endl;
-	}
+        if(v == entry){
+            v.spread(input, events);
+            std::cout << "Input: " << input[0] << " " << cage.comm.getGlobalContext().getVAddr() << std::endl;
+        }
 
-	if(v == exit){
-	    v.collect(output);
-	    std::cout << "Output: " << output[0] << std::endl;
-	}
+        if(v == exit){
+            v.collect(output);
+            std::cout << "Output: " << output[0] << " " << cage.comm.getGlobalContext().getVAddr() << std::endl;
+        }
 
-	if(v != entry and v != exit){
-	    v.collect(intermediate);
-	    inc(intermediate[0]);
-	    std::cout << "Increment: " << intermediate[0] << std::endl;
-	    v.spread(intermediate, events);
+        if(v != entry and v != exit){
+            v.collect(intermediate);
+            inc(intermediate[0]);
+            std::cout << "Increment: " << intermediate[0] << " " << cage.comm.getGlobalContext().getVAddr() << std::endl;
+            v.spread(intermediate, events);
 	    
-	}
+        }
 	
     }
 
     for(unsigned i = 0; i < events.size(); ++i){
-	events.back().wait();
-	events.pop_back();
+        events.back().wait();
+        events.pop_back();
     }
     
     return 0;

--- a/example/forward.cpp
+++ b/example/forward.cpp
@@ -63,7 +63,7 @@ int exp() {
     Cage cage(config);
 
     // Set communication pattern
-    cage.setGraph(graybat::pattern::Chain(nChainLinks));
+    cage.setGraph(graybat::pattern::Chain<GP>(nChainLinks));
 
     // Distribute vertices
     cage.distribute(graybat::mapping::Consecutive());

--- a/example/gol.cpp
+++ b/example/gol.cpp
@@ -117,7 +117,7 @@ int gol(const unsigned nCells, const unsigned nTimeSteps ) {
     // Create GoL Graph
     Config config;
     Cage grid(config);
-    grid.setGraph(graybat::pattern::GridDiagonal(height, width));
+    grid.setGraph(graybat::pattern::GridDiagonal<GP>(height, width));
 
     
     // Distribute vertices

--- a/example/ring.cpp
+++ b/example/ring.cpp
@@ -61,7 +61,7 @@ int exp() {
     assert(cage.getPeers().size() >= nRingLinks);
 
     // Create ring communication pattern
-    cage.setGraph(graybat::pattern::Ring(nRingLinks));
+    cage.setGraph(graybat::pattern::Ring<GP>(nRingLinks));
 
     
     // Distribute vertices

--- a/include/graybat/Cage.hpp
+++ b/include/graybat/Cage.hpp
@@ -68,7 +68,7 @@ namespace graybat {
 	
 	Cage(CPConfig const cpConfig) :
 	    comm(cpConfig),
-	    graph(GraphPolicy(graybat::pattern::None()())){
+	    graph(GraphPolicy(graybat::pattern::None<GraphPolicy>()())){
 
 	}
 

--- a/include/graybat/graphPolicy/BGL.hpp
+++ b/include/graybat/graphPolicy/BGL.hpp
@@ -25,7 +25,7 @@ namespace graybat {
 	    ID id;
 	};
 
-	/************************************************************************//**
+  	/************************************************************************//**
          * @class BGL
 	 *									   
 	 * @brief A class to describe directed graphs.
@@ -39,11 +39,13 @@ namespace graybat {
 	public:
 	    // Public typedefs
 	    typedef T_VertexProperty                                                VertexProperty;
-	    typedef T_EdgeProperty                                                  EdgeProperty;	    
-	    typedef std::pair<unsigned, unsigned>                                   EdgeDescription;
-	    typedef std::pair<std::vector<unsigned>, std::vector<EdgeDescription> > GraphDescription;
+	    typedef T_EdgeProperty                                                  EdgeProperty;
 
-	    typedef unsigned                                                        GraphID;
+            using VertexDescription = graybat::graphPolicy::VertexDescription<BGL>;
+            using EdgeDescription   = graybat::graphPolicy::EdgeDescription<BGL>;
+            using GraphDescription  = graybat::graphPolicy::GraphDescription<BGL>;
+            
+	    typedef unsigned                                                                 GraphID;
 
 
 	    // BGL typdefs
@@ -62,8 +64,6 @@ namespace graybat {
 	    typedef typename boost::graph_traits<BGLGraph>::adjacency_iterator AdjacentVertexIter;
 	    typedef typename boost::graph_traits<BGLGraph>::vertex_iterator    AllVertexIter;
 	    
-
-
 	    // Member
 	    BGLGraph* graph;
 	    std::vector<BGL<VertexProperty, EdgeProperty>> subGraphs;
@@ -82,25 +82,25 @@ namespace graybat {
 	    BGL(GraphDescription graphDesc) :
 		id(0){
 
-		std::vector<unsigned> vertices     = graphDesc.first;
-		std::vector<EdgeDescription> edges = graphDesc.second;
+		std::vector<VertexDescription> vertices = graphDesc.first;
+		std::vector<EdgeDescription> edges      = graphDesc.second;
 
 		graph = new BGLGraph(vertices.size());
 
 		unsigned edgeCount = 0;
 
 		for(EdgeDescription edge: edges){
-		    VertexID srcVertex    = std::get<0>(edge);
-		    VertexID targetVertex = std::get<1>(edge);
+		    VertexID srcVertex    = std::get<0>(edge.first);
+		    VertexID targetVertex = std::get<1>(edge.first);
 		    EdgeID edgeID = boost::add_edge(srcVertex, targetVertex, (*graph)).first;
                     edgeIdMap.push_back(edgeID);
-		    setEdgeProperty(edgeID, std::make_pair(edgeCount++, EdgeProperty()));
+		    setEdgeProperty(edgeID, std::make_pair(edgeCount++, edge.second));
 		}
 
 		// Bind vertex_descriptor and VertexProperty;
-		for(unsigned vertexID = 0; vertexID < vertices.size(); ++vertexID){
-		    setVertexProperty(vertexID, std::make_pair(vertexID, VertexProperty()));
-		}
+                for(VertexDescription &v : vertices){
+                    setVertexProperty(v.first, std::make_pair(v.first, v.second));
+                }
 		
 	    }	    
 

--- a/include/graybat/graphPolicy/Traits.hpp
+++ b/include/graybat/graphPolicy/Traits.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+// STL
+#include <utility> /* std::pair */
+#include <vector>
+
+namespace graybat {
+
+    namespace graphPolicy {
+
+        // namespace traits {
+        // }
+
+        template <typename T_GraphPolicy>
+        using VertexProperty = typename T_GraphPolicy::VertexProperty;
+
+        template <typename T_GraphPolicy>
+        using EdgeProperty = typename T_GraphPolicy::EdgeProperty;
+
+        using VertexID = size_t;
+        
+        template <typename T_GraphPolicy>        
+        using VertexDescription = std::pair<VertexID, VertexProperty<T_GraphPolicy> >;
+
+        template <typename T_GraphPolicy>        
+        using EdgeDescription = std::pair< std::pair<
+                                               VertexID
+                                               ,VertexID >
+                                           ,EdgeProperty<T_GraphPolicy> >;
+
+        template <typename T_GraphPolicy>
+        using GraphDescription = std::pair<
+            std::vector<VertexDescription<T_GraphPolicy> >,
+            std::vector<EdgeDescription<T_GraphPolicy> >
+            >;
+
+        
+    } // namespace graphPolicy
+    
+} // namespace graybat

--- a/include/graybat/mapping/Filter.hpp
+++ b/include/graybat/mapping/Filter.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <algorithm> /* std::sort*/
+#include <vector>    /* std::vector */
+
+namespace graybat {
+    
+    namespace mapping {
+    
+	struct Filter {
+
+            const size_t vertexTag;
+            
+            Filter(size_t vertexTag):
+                vertexTag(vertexTag){
+
+            }
+        
+	    template<typename T_Cage>
+	    std::vector<typename T_Cage::Vertex> operator()(const unsigned processID, const unsigned processCount, T_Cage &cage){
+
+                using CommunicationPolicy = typename T_Cage::CommunicationPolicy;
+                using Vertex              = typename T_Cage::Vertex;
+                using Context             = typename CommunicationPolicy::Context;
+                using VAddr               = typename CommunicationPolicy::VAddr;
+
+                std::vector<VAddr> peersWithSameTag;
+                
+                CommunicationPolicy& comm = cage.comm;
+                Context context = comm.getGlobalContext();
+                
+
+                // Get the information about who wants to
+                // host vertices with the same tag
+                std::array<size_t, 1> sendData{vertexTag};                
+                for(VAddr vAddr = 0; vAddr < context.size(); vAddr++){
+                    comm.asyncSend(vAddr, 0, context, sendData);
+                }
+
+                for(VAddr vAddr = 0; vAddr < context.size(); vAddr++){
+                    std::array<size_t, 1> recvData{0};
+                    comm.recv(vAddr, 0, context, recvData);
+                    if(recvData[0] == vertexTag){
+                        peersWithSameTag.push_back(vAddr);
+                    }
+                }
+
+                // Distribute vertices to peers with same tag
+                std::sort(peersWithSameTag.begin(), peersWithSameTag.end());
+
+                const size_t nPeers = peersWithSameTag.size();
+                size_t peer_i = 0;
+                
+                std::vector<Vertex> vertices = cage.getVertices();
+                std::vector<Vertex> myVertices;
+                
+                for(size_t i = 0; i < vertices.size(); ++i){
+                    if(vertices[i]().tag == vertexTag){
+                        if(peersWithSameTag.at(peer_i) == context.getVAddr()){
+                            myVertices.push_back(vertices[i]);
+                            
+                        }
+                        peer_i = (peer_i + 1 % nPeers);
+                        
+                    }
+
+                }
+                
+ 		return myVertices;
+
+	    }
+
+	};
+
+    } /* mapping */
+    
+} /* graybat */

--- a/include/graybat/pattern/BiStar.hpp
+++ b/include/graybat/pattern/BiStar.hpp
@@ -1,47 +1,51 @@
-/*******************************************************************************
- *
- * GRAPH TOPOLOGY GENERATORS
- *
- *******************************************************************************/
+# pragma once
 
+// STL
+#include <utility> /* std::make_pair */
+
+// GRAYBAT
+#include <graybat/graphPolicy/Traits.hpp>
 namespace graybat {
 
-  namespace pattern {
+    namespace pattern {
 
-    typedef unsigned                                                        VertexID;
-    typedef std::pair<VertexID, VertexID>                                   EdgeDescription;
-    typedef std::pair<std::vector<VertexID>, std::vector<EdgeDescription> > GraphDescription;
+        template<typename T_GraphPolicy>
+        struct BiStar {
 
+            using GraphPolicy       = T_GraphPolicy;
+            using VertexDescription = graybat::graphPolicy::VertexDescription<GraphPolicy>;
+            using EdgeDescription   = graybat::graphPolicy::EdgeDescription<GraphPolicy>;
+            using GraphDescription  = graybat::graphPolicy::GraphDescription<GraphPolicy>;
+            using EdgeProperty      = graybat::graphPolicy::EdgeProperty<GraphPolicy>;
+            using VertexProperty    = graybat::graphPolicy::VertexProperty<GraphPolicy>;  
+
+            const unsigned verticesCount;
+
+            BiStar(const unsigned verticesCount) :
+                verticesCount(verticesCount) {
+
+            }
     
-    struct BiStar {
 
-      const unsigned verticesCount;
-
-      BiStar(const unsigned verticesCount) :
-	verticesCount(verticesCount) {
-
-      }
+            GraphDescription operator()(){
+                std::vector<VertexDescription> vertices(verticesCount);
     
+                std::vector<EdgeDescription> edges;
 
-      GraphDescription operator()(){
-	std::vector<VertexID> vertices(verticesCount);
-    
-	std::vector<EdgeDescription> edges;
-
-	for(unsigned i = 0; i < vertices.size(); ++i){
-	  vertices.at(i) = i;
-	  if(i != 0){
-	    edges.push_back(std::make_pair(i, 0));
-	    edges.push_back(std::make_pair(0, i));
-	  }
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    vertices.at(i) = std::make_pair(i, VertexProperty());
+                    if(i != 0){
+                        edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[0].first), EdgeProperty()));
+                        edges.push_back(std::make_pair(std::make_pair(vertices[0].first, vertices[i].first), EdgeProperty()));
+                    }
 		
-	}
+                }
 
-	return std::make_pair(vertices,edges);
-      }
+                return std::make_pair(vertices,edges);
+            }
 
-    };
+        };
 
-  } /* pattern */
+    } /* pattern */
 
 } /* graybat */

--- a/include/graybat/pattern/Chain.hpp
+++ b/include/graybat/pattern/Chain.hpp
@@ -1,44 +1,69 @@
-/*******************************************************************************
- *
- * GRAPH TOPOLOGY GENERATORS
- *
- *******************************************************************************/
+#pragma once
+
+// STL
+#include <utility> /* std::make_pair */
+
+// GRAYBAT
+#include <graybat/graphPolicy/Traits.hpp>
 
 namespace graybat {
 
-  namespace pattern {
+    namespace pattern {
 
-    typedef unsigned                                                        VertexID;
-    typedef std::pair<VertexID, VertexID>                                   EdgeDescription;
-    typedef std::pair<std::vector<VertexID>, std::vector<EdgeDescription> > GraphDescription;
 
+
+        template<typename T_GraphPolicy>
+        struct Chain {
+
+            using GraphPolicy       = T_GraphPolicy;
+            using VertexDescription = graybat::graphPolicy::VertexDescription<GraphPolicy>;
+            using EdgeDescription   = graybat::graphPolicy::EdgeDescription<GraphPolicy>;
+            using GraphDescription  = graybat::graphPolicy::GraphDescription<GraphPolicy>;
+            using EdgeProperty      = graybat::graphPolicy::EdgeProperty<GraphPolicy>;
+            using VertexProperty    = graybat::graphPolicy::VertexProperty<GraphPolicy>;            
+            
+            const unsigned verticesCount;
+
+            Chain(const unsigned verticesCount) :
+                verticesCount(verticesCount) {
+
+            }
     
-    struct Chain {
 
-      const unsigned verticesCount;
+            GraphDescription operator()(){
+                std::vector<VertexDescription> vertices;
+                
+                for(size_t i = 0; i < verticesCount; ++i){
+                    if(i == 0){
+                        vertices.push_back(std::make_pair(i, VertexProperty()));
+                        
+                    }
+                    else if(i == verticesCount - 1){
+                        vertices.push_back(std::make_pair(i, VertexProperty()));
+                        
+                    }
+                    else {
+                        vertices.push_back(std::make_pair(i, VertexProperty()));
+                        
+                    }
+                    
+                }
+                
+                std::vector<EdgeDescription> edges;
+                if(vertices.size() != 1) {
+                    for(size_t i = 0; i < vertices.size() - 1; ++i){
+                        edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[i + 1].first), EdgeProperty()));
+                            
+                    }
+                    
+                }
 
-      Chain(const unsigned verticesCount) :
-	verticesCount(verticesCount) {
+                return std::make_pair(vertices,edges);
+            
+            }
 
-      }
-    
+        };
 
-      GraphDescription operator()(){
-	std::vector<VertexID> vertices(verticesCount);
-    	std::vector<EdgeDescription> edges;
-
-	if(vertices.size() != 1) {
-	    for(unsigned i = 0; i < vertices.size() - 1; ++i){
-		edges.push_back(std::make_pair(i, i + 1));
-		
-	    }
-	}
-
-	return std::make_pair(vertices,edges);
-      }
-
-    };
-
-  } /* pattern */
+    } /* pattern */
 
 } /* graybat */

--- a/include/graybat/pattern/EdgeLess.hpp
+++ b/include/graybat/pattern/EdgeLess.hpp
@@ -1,29 +1,39 @@
+# pragma once
+
+// STL
+#include <utility> /* std::make_pair */
+
+// GRAYBAT
+#include <graybat/graphPolicy/Traits.hpp>
+
 namespace graybat {
 
   namespace pattern {
 
-    typedef unsigned                                                        VertexID;
-    typedef std::pair<VertexID, VertexID>                                   EdgeDescription;
-    typedef std::pair<std::vector<VertexID>, std::vector<EdgeDescription> > GraphDescription;
 
+      template<typename T_GraphPolicy>
+      struct EdgeLess {
 
-    struct EdgeLess {
+          using GraphPolicy       = T_GraphPolicy;
+          using VertexDescription = graybat::graphPolicy::VertexDescription<GraphPolicy>;
+          using EdgeDescription   = graybat::graphPolicy::EdgeDescription<GraphPolicy>;
+          using GraphDescription  = graybat::graphPolicy::GraphDescription<GraphPolicy>;
 
-      const unsigned verticesCount;
+          const unsigned verticesCount;
 
-	EdgeLess(const unsigned verticesCount) :
-	    verticesCount(verticesCount){
+          EdgeLess(const unsigned verticesCount) :
+              verticesCount(verticesCount){
 
-      }
+          }
       
-      GraphDescription operator()(){
-	std::vector<VertexID> vertices(verticesCount);
-	assert(vertices.size() == verticesCount);
-	std::vector<EdgeDescription> edges;
-	return std::make_pair(vertices,edges);
-      }
+          GraphDescription operator()(){
+              std::vector<VertexDescription> vertices(verticesCount);
+              assert(vertices.size() == verticesCount);
+              std::vector<EdgeDescription> edges;
+              return std::make_pair(vertices,edges);
+          }
 
-    };
+      };
       
   } /* pattern */
 

--- a/include/graybat/pattern/FullyConnected.hpp
+++ b/include/graybat/pattern/FullyConnected.hpp
@@ -1,54 +1,62 @@
-/*******************************************************************************
- *
- * GRAPH TOPOLOGY GENERATORS
- *
- *******************************************************************************/
+# pragma once
+
+// STL
+#include <utility> /* std::make_pair */
+
+// GRAYBAT
+#include <graybat/graphPolicy/Traits.hpp>
 
 namespace graybat {
 
-  namespace pattern {
+    namespace pattern {
 
-    typedef unsigned                                                        VertexID;
-    typedef std::pair<VertexID, VertexID>                                   EdgeDescription;
-    typedef std::pair<std::vector<VertexID>, std::vector<EdgeDescription> > GraphDescription;
+        template<typename T_GraphPolicy>
+        struct FullyConnected {
 
+            using GraphPolicy       = T_GraphPolicy;
+            using VertexDescription = graybat::graphPolicy::VertexDescription<GraphPolicy>;
+            using EdgeDescription   = graybat::graphPolicy::EdgeDescription<GraphPolicy>;
+            using GraphDescription  = graybat::graphPolicy::GraphDescription<GraphPolicy>;
+            using EdgeProperty      = graybat::graphPolicy::EdgeProperty<GraphPolicy>;
+            using VertexProperty    = graybat::graphPolicy::VertexProperty<GraphPolicy>;  
 
-    struct FullyConnected {
+            const unsigned verticesCount;
 
-      const unsigned verticesCount;
+            FullyConnected(const unsigned verticesCount) :
+                verticesCount(verticesCount){
 
-      FullyConnected(const unsigned verticesCount) :
-	verticesCount(verticesCount){
-
-      }
+            }
       
-      GraphDescription operator()(){
-	std::vector<VertexID> vertices(verticesCount);
+            GraphDescription operator()(){
+                std::vector<VertexDescription> vertices(verticesCount);
 
-	assert(vertices.size() == verticesCount);
+                assert(vertices.size() == verticesCount);
 
-	std::vector<EdgeDescription> edges;
+                std::vector<EdgeDescription> edges;
 
-	for(unsigned i = 0; i < vertices.size(); ++i){
-	  vertices.at(i) = i;
-	  for(unsigned j = 0; j < vertices.size(); ++j){
-	    if(i == j){
-	      continue;
-	    } 
-	    else {
-	      edges.push_back(std::make_pair(i, j));
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    vertices.at(i) = std::make_pair(i, VertexProperty());
+                }
+                
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    for(unsigned j = 0; j < vertices.size(); ++j){
+                        if(i == j){
+                            continue;
+                        } 
+                        else {
+                            edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[j].first), EdgeProperty()));
 	      
-	    }
+                        }
 	    
-	  }
+                    }
 
-	}
+                }
 
-	return std::make_pair(vertices,edges);
-      }
+                return std::make_pair(vertices,edges);
+            }
 
-    };
+        };
       
-  } /* pattern */
+    } /* pattern */
 
 } /* graybat */

--- a/include/graybat/pattern/Grid.hpp
+++ b/include/graybat/pattern/Grid.hpp
@@ -1,68 +1,74 @@
-/*******************************************************************************
- *
- * GRAPH TOPOLOGY GENERATORS
- *
- *******************************************************************************/
+# pragma once
+
+// STL
+#include <utility> /* std::make_pair */
+
+// GRAYBAT
+#include <graybat/graphPolicy/Traits.hpp>
 
 namespace graybat {
 
-  namespace pattern {
+    namespace pattern {
 
-    typedef unsigned                                                        VertexID;
-    typedef std::pair<VertexID, VertexID>                                   EdgeDescription;
-    typedef std::pair<std::vector<VertexID>, std::vector<EdgeDescription> > GraphDescription;
+        template<typename T_GraphPolicy>
+        struct Grid {
 
+            using GraphPolicy       = T_GraphPolicy;
+            using VertexDescription = graybat::graphPolicy::VertexDescription<GraphPolicy>;
+            using EdgeDescription   = graybat::graphPolicy::EdgeDescription<GraphPolicy>;
+            using GraphDescription  = graybat::graphPolicy::GraphDescription<GraphPolicy>;
+            using EdgeProperty      = graybat::graphPolicy::EdgeProperty<GraphPolicy>;
+            using VertexProperty    = graybat::graphPolicy::VertexProperty<GraphPolicy>;  
+          
+            const unsigned height;
+            const unsigned width;
 
+            Grid(const unsigned height, const unsigned width) :
+                height(height),
+                width(width){
 
-    struct Grid {
-
-      const unsigned height;
-      const unsigned width;
-	
-      Grid(const unsigned height, const unsigned width) :
-	height(height),
-	width(width){
-
-      }
+            }
     
-      GraphDescription operator()(){
+            GraphDescription operator()(){
 
-	const unsigned verticesCount = height * width;
-	std::vector<unsigned> vertices(verticesCount);
-	std::vector<EdgeDescription> edges;
+                const unsigned verticesCount = height * width;
+                std::vector<VertexDescription> vertices(verticesCount);
+                std::vector<EdgeDescription> edges;
 
-	for(unsigned i = 0; i < vertices.size(); ++i){
-	  vertices.at(i) = i;
-	    
-	  if(i >= width){
-	    unsigned up   = i - width;
-	    edges.push_back(std::make_pair(i, up));
-	  }
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    vertices.at(i) = std::make_pair(i, VertexProperty());
+                }
+                
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    if(i >= width){
+                        unsigned up   = i - width;
+                        edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[up].first), EdgeProperty()));
+                    }
 
-	  if(i < (verticesCount - width)){
-	    unsigned down = i + width;
-	    edges.push_back(std::make_pair(i,down));
-	  }
+                    if(i < (verticesCount - width)){
+                        unsigned down = i + width;
+                        edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[down].first), EdgeProperty()));
+                    }
 
 
-	  if((i % width) != (width - 1)){
-	    int right = i + 1;
-	    edges.push_back(std::make_pair(i,right));
-	  }
+                    if((i % width) != (width - 1)){
+                        int right = i + 1;
+                        edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[right].first), EdgeProperty()));
+                    }
 
-	  if((i % width) != 0){
-	    int left = i - 1;
-	    edges.push_back(std::make_pair(i, left));
-	  }
+                    if((i % width) != 0){
+                        int left = i - 1;
+                        edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[left].first), EdgeProperty()));
+                    }
 	
 
-	}
+                }
 
-	return std::make_pair(vertices,edges);
-      }
+                return std::make_pair(vertices,edges);
+            }
 
-    };
+        };
 
-  } /* pattern */
+    } /* pattern */
 
 } /* graybat */

--- a/include/graybat/pattern/GridDiagonal.hpp
+++ b/include/graybat/pattern/GridDiagonal.hpp
@@ -1,91 +1,99 @@
-/*******************************************************************************
- *
- * GRAPH TOPOLOGY GENERATORS
- *
- *******************************************************************************/
+# pragma once
+
+// STL
+#include <utility> /* std::make_pair */
+
+// GRAYBAT
+#include <graybat/graphPolicy/Traits.hpp>
+
 
 namespace graybat {
 
   namespace pattern {
 
-    typedef unsigned                                                        VertexID;
-    typedef std::pair<VertexID, VertexID>                                   EdgeDescription;
-    typedef std::pair<std::vector<VertexID>, std::vector<EdgeDescription> > GraphDescription;
+      template<typename T_GraphPolicy>
+      struct GridDiagonal {
 
-    struct GridDiagonal {
+          using GraphPolicy       = T_GraphPolicy;
+          using VertexDescription = graybat::graphPolicy::VertexDescription<GraphPolicy>;
+          using EdgeDescription   = graybat::graphPolicy::EdgeDescription<GraphPolicy>;
+          using GraphDescription  = graybat::graphPolicy::GraphDescription<GraphPolicy>;
+          using EdgeProperty      = graybat::graphPolicy::EdgeProperty<GraphPolicy>;
+          using VertexProperty    = graybat::graphPolicy::VertexProperty<GraphPolicy>;          
 
-	const unsigned height;
-	const unsigned width;
-	
-	GridDiagonal(const unsigned height, const unsigned width) :
-	    height(height),
-	    width(width){
+          const unsigned height;
+          const unsigned width;
 
-	}
+          GridDiagonal(const unsigned height, const unsigned width) :
+              height(height),
+              width(width){
+
+          }
     
-	GraphDescription operator()(){
-	    const unsigned verticesCount = height * width;
-	    std::vector<unsigned> vertices(verticesCount);
-	    std::vector<EdgeDescription > edges;
+          GraphDescription operator()(){
+              const unsigned verticesCount = height * width;
+              std::vector<VertexDescription> vertices(verticesCount);
+              std::vector<EdgeDescription > edges;
 
-	    for(unsigned i = 0; i < vertices.size(); ++i){
-		vertices.at(i) = i;
-	    
-		// UP
-		if(i >= width){
-		    unsigned up   = i - width;
-		    edges.push_back(std::make_pair(i, up));
-		}
+              for(unsigned i = 0; i < vertices.size(); ++i){
+                  vertices.at(i) = std::make_pair(i, VertexProperty());
+              }
+              
+              for(unsigned i = 0; i < vertices.size(); ++i){
 
-		// UP LEFT
-		if(i >= width and (i % width) != 0){
-		    unsigned up_left   = i - width - 1;
-		    edges.push_back(std::make_pair(i, up_left));
-		}
+                  // UP
+                  if(i >= width){
+                      unsigned up   = i - width;
+                      edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[up].first), EdgeProperty()));
+                  }
 
-		// UP RIGHT
-		if(i >= width and (i % width) != (width - 1)){
-		    unsigned up_right   = i - width + 1;
-		    edges.push_back(std::make_pair(i, up_right));
-		}
+                  // UP LEFT
+                  if(i >= width and (i % width) != 0){
+                      unsigned up_left   = i - width - 1;
+                      edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[up_left].first), EdgeProperty()));
+                  }
 
-		// DOWN
-		if(i < (verticesCount - width)){
-		    unsigned down = i + width;
-		    edges.push_back(std::make_pair(i, down));
-		}
+                  // UP RIGHT
+                  if(i >= width and (i % width) != (width - 1)){
+                      unsigned up_right   = i - width + 1;
+                      edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[up_right].first), EdgeProperty()));
+                  }
 
-		// DOWN LEFT
-		if(i < (verticesCount - width) and (i % width) != 0){
-		    unsigned down_left = i + width - 1;
-		    edges.push_back(std::make_pair(i, down_left));
-		}
+                  // DOWN
+                  if(i < (verticesCount - width)){
+                      unsigned down = i + width;
+                      edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[down].first), EdgeProperty()));
+                  }
 
-		// DOWN RIGHT
-		if(i < (verticesCount - width) and (i % width) != (width - 1)){
-		    unsigned down_right = i + width + 1;
-		    edges.push_back(std::make_pair(i, down_right));
-		}
+                  // DOWN LEFT
+                  if(i < (verticesCount - width) and (i % width) != 0){
+                      unsigned down_left = i + width - 1;
+                      edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[down_left].first), EdgeProperty()));
+                  }
 
-		// RIGHT
-		if((i % width) != (width - 1)){
-		    int right = i + 1;
-		    edges.push_back(std::make_pair(i, right));
-		}
+                  // DOWN RIGHT
+                  if(i < (verticesCount - width) and (i % width) != (width - 1)){
+                      unsigned down_right = i + width + 1;
+                      edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[down_right].first), EdgeProperty()));
+                  }
 
-		// LEFT
-		if((i % width) != 0){
-		    int left = i - 1;
-		    edges.push_back(std::make_pair(i, left));
-		}
+                  // RIGHT
+                  if((i % width) != (width - 1)){
+                      int right = i + 1;
+                      edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[right].first), EdgeProperty()));
+                  }
 
-	    
+                  // LEFT
+                  if((i % width) != 0){
+                      int left = i - 1;
+                      edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[left].first), EdgeProperty()));
+                  }
 
-	    }
-	    return std::make_pair(vertices,edges);
-	}
-	
-    };
+              }
+              return std::make_pair(vertices,edges);
+          }
+
+      };
 
   } /* pattern */
 

--- a/include/graybat/pattern/HyperCube.hpp
+++ b/include/graybat/pattern/HyperCube.hpp
@@ -1,54 +1,62 @@
-/*******************************************************************************
- *
- * GRAPH TOPOLOGY GENERATORS
- *
- *******************************************************************************/
+# pragma once
+
+// STL
+#include <utility> /* std::make_pair */
+
+// GRAYBAT
+#include <graybat/graphPolicy/Traits.hpp>
 
 namespace graybat {
 
-  namespace pattern {
+    namespace pattern {
 
-    typedef unsigned                                                        VertexID;
-    typedef std::pair<VertexID, VertexID>                                   EdgeDescription;
-    typedef std::pair<std::vector<VertexID>, std::vector<EdgeDescription> > GraphDescription;
+        template<typename T_GraphPolicy>    
+        struct HyperCube {
 
-    
-    struct HyperCube {
+            using GraphPolicy       = T_GraphPolicy;
+            using VertexDescription = graybat::graphPolicy::VertexDescription<GraphPolicy>;
+            using EdgeDescription   = graybat::graphPolicy::EdgeDescription<GraphPolicy>;
+            using GraphDescription  = graybat::graphPolicy::GraphDescription<GraphPolicy>;
+            using EdgeProperty      = graybat::graphPolicy::EdgeProperty<GraphPolicy>;
+            using VertexProperty    = graybat::graphPolicy::VertexProperty<GraphPolicy>;  
+            
+            const unsigned dimension;
 
-      const unsigned dimension;
+            HyperCube(const unsigned dimension) :
+                dimension(dimension){
 
-      HyperCube(const unsigned dimension) :
-	dimension(dimension){
-
-      }
+            }
       
-      unsigned hammingDistance(unsigned a, unsigned b){
-	unsigned abXor = a xor b;
-	return (unsigned) __builtin_popcount(abXor);
-      }
+            unsigned hammingDistance(unsigned a, unsigned b){
+                unsigned abXor = a xor b;
+                return (unsigned) __builtin_popcount(abXor);
+            }
 
-      GraphDescription operator()(){
-	assert(dimension >= 1);
-	std::vector<EdgeDescription> edges;
+            GraphDescription operator()(){
+                assert(dimension >= 1);
+                std::vector<EdgeDescription> edges;
 
-	unsigned verticesCount = pow(2, dimension);
-	std::vector<VertexID> vertices(verticesCount);
+                unsigned verticesCount = pow(2, dimension);
+                std::vector<VertexDescription> vertices(verticesCount);
 
-	for(unsigned i = 0; i < vertices.size(); ++i){
-	  vertices.at(i) = i;
-	  for(unsigned j = 0; j < vertices.size(); ++j){
-	    if(hammingDistance(i, j) == 1){
-	      edges.push_back(std::make_pair(i, j));
-	    }
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    vertices.at(i) = std::make_pair(i, VertexProperty());
+                }
+                
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    for(unsigned j = 0; j < vertices.size(); ++j){
+                        if(hammingDistance(i, j) == 1){
+                            edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[j].first), EdgeProperty()));
+                        }
 
-	  }
-	}
+                    }
+                }
     
-	return std::make_pair(vertices,edges);
-      }
+                return std::make_pair(vertices,edges);
+            }
 
-    };
+        };
 
-  } /* pattern */
+    } /* pattern */
 
 } /* graybat */

--- a/include/graybat/pattern/InStar.hpp
+++ b/include/graybat/pattern/InStar.hpp
@@ -1,46 +1,57 @@
-/*******************************************************************************
- *
- * GRAPH TOPOLOGY GENERATORS
- *
- *******************************************************************************/
+# pragma once
+
+// STL
+#include <utility> /* std::make_pair */
+
+// GRAYBAT
+#include <graybat/graphPolicy/Traits.hpp>
+
 
 namespace graybat {
 
-  namespace pattern {
+    namespace pattern {
 
-    typedef unsigned                                                        VertexID;
-    typedef std::pair<VertexID, VertexID>                                   EdgeDescription;
-    typedef std::pair<std::vector<VertexID>, std::vector<EdgeDescription> > GraphDescription;
+        template<typename T_GraphPolicy>
+        struct InStar {
 
+          
+            using GraphPolicy       = T_GraphPolicy;
+            using VertexDescription = graybat::graphPolicy::VertexDescription<GraphPolicy>;
+            using EdgeDescription   = graybat::graphPolicy::EdgeDescription<GraphPolicy>;
+            using GraphDescription  = graybat::graphPolicy::GraphDescription<GraphPolicy>;
+            using EdgeProperty      = graybat::graphPolicy::EdgeProperty<GraphPolicy>;
+            using VertexProperty    = graybat::graphPolicy::VertexProperty<GraphPolicy>;  
+
+
+            const unsigned verticesCount;
+
+            InStar(const unsigned verticesCount) :
+                verticesCount(verticesCount) {
+
+            }
     
-    struct InStar {
 
-      const unsigned verticesCount;
+            GraphDescription operator()(){
+                std::vector<VertexDescription> vertices(verticesCount);
+                std::vector<EdgeDescription> edges;
 
-      InStar(const unsigned verticesCount) :
-	verticesCount(verticesCount) {
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    vertices.at(i) = std::make_pair(i, VertexProperty());
+                }
 
-      }
-    
-
-      GraphDescription operator()(){
-	std::vector<VertexID> vertices(verticesCount);
-    
-	std::vector<EdgeDescription> edges;
-
-	for(unsigned i = 0; i < vertices.size(); ++i){
-	  vertices.at(i) = i;
-	  if(i != 0){
-	    edges.push_back(std::make_pair(i, 0));
-	  }
+                    
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    if(i != 0){
+                        edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[0].first), EdgeProperty()));
+                    }
 		
-	}
+                }
 
-	return std::make_pair(vertices,edges);
-      }
+                return std::make_pair(vertices,edges);
+            }
 
-    };
+        };
 
-  } /* pattern */
+    } /* namespace pattern */
 
-} /* graybat */
+} /* namespace graybat */

--- a/include/graybat/pattern/None.hpp
+++ b/include/graybat/pattern/None.hpp
@@ -1,29 +1,27 @@
-/*******************************************************************************
- *
- * GRAPH TOPOLOGY GENERATORS
- *
- *******************************************************************************/
+#pragma once
+
+#include <graybat/graphPolicy/Traits.hpp>
 
 namespace graybat {
 
-  namespace pattern {
+    namespace pattern {
 
-    typedef unsigned                                                        VertexID;
-    typedef std::pair<VertexID, VertexID>                                   EdgeDescription;
-    typedef std::pair<std::vector<VertexID>, std::vector<EdgeDescription> > GraphDescription;
 
-    
-    struct None {
-      GraphDescription operator()(){
-	  std::vector<VertexID> vertices;
-    
-	  std::vector<EdgeDescription> edges;
+        template <typename T_GraphPolicy>
+        struct None {
+            using VertexDescription = graybat::graphPolicy::VertexDescription<T_GraphPolicy>;
+            using EdgeDescription   = graybat::graphPolicy::EdgeDescription<T_GraphPolicy>;
+            using GraphDescription  = graybat::graphPolicy::GraphDescription<T_GraphPolicy>;
+            
+            GraphDescription operator()(){
+                std::vector<VertexDescription> vertices;
+                std::vector<EdgeDescription> edges;
 
-	  return std::make_pair(vertices,edges);
-      }
+                return std::make_pair(vertices,edges);
+            }
 
-    };
+        };
 
-  } /* pattern */
+    } /* pattern */
 
 } /* graybat */

--- a/include/graybat/pattern/OutStar.hpp
+++ b/include/graybat/pattern/OutStar.hpp
@@ -1,46 +1,57 @@
-/*******************************************************************************
- *
- * GRAPH TOPOLOGY GENERATORS
- *
- *******************************************************************************/
+# pragma once
+
+// STL
+#include <utility> /* std::make_pair */
+
+// GRAYBAT
+#include <graybat/graphPolicy/Traits.hpp>
+
 
 namespace graybat {
 
-  namespace pattern {
+    namespace pattern {
 
-    typedef unsigned                                                        VertexID;
-    typedef std::pair<VertexID, VertexID>                                   EdgeDescription;
-    typedef std::pair<std::vector<VertexID>, std::vector<EdgeDescription> > GraphDescription;
+        template<typename T_GraphPolicy>
+        struct OutStar {
 
+          
+            using GraphPolicy       = T_GraphPolicy;
+            using VertexDescription = graybat::graphPolicy::VertexDescription<GraphPolicy>;
+            using EdgeDescription   = graybat::graphPolicy::EdgeDescription<GraphPolicy>;
+            using GraphDescription  = graybat::graphPolicy::GraphDescription<GraphPolicy>;
+            using EdgeProperty      = graybat::graphPolicy::EdgeProperty<GraphPolicy>;
+            using VertexProperty    = graybat::graphPolicy::VertexProperty<GraphPolicy>;  
+
+
+            const unsigned verticesCount;
+
+            OutStar(const unsigned verticesCount) :
+                verticesCount(verticesCount) {
+
+            }
     
-    struct OutStar {
 
-      const unsigned verticesCount;
+            GraphDescription operator()(){
+                std::vector<VertexDescription> vertices(verticesCount);
+                    std::vector<EdgeDescription> edges;
 
-      OutStar(const unsigned verticesCount) :
-	verticesCount(verticesCount) {
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    vertices.at(i) = std::make_pair(i, VertexProperty());
+                }
 
-      }
-    
-
-      GraphDescription operator()(){
-	std::vector<VertexID> vertices(verticesCount);
-    
-	std::vector<EdgeDescription> edges;
-
-	for(unsigned i = 0; i < vertices.size(); ++i){
-	  vertices.at(i) = i;
-	  if(i != 0){
-	    edges.push_back(std::make_pair(0, i));
-	  }
+                
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    if(i != 0){
+                        edges.push_back(std::make_pair(std::make_pair(vertices[0].first, vertices[i].first), EdgeProperty()));
+                    }
 		
-	}
+                }
 
-	return std::make_pair(vertices,edges);
-      }
+                return std::make_pair(vertices,edges);
+            }
 
-    };
+        };
 
-  } /* pattern */
+    } /* namespace pattern */
 
-} /* graybat */
+} /* namespace graybat */

--- a/include/graybat/pattern/Ring.hpp
+++ b/include/graybat/pattern/Ring.hpp
@@ -1,21 +1,27 @@
-/*******************************************************************************
- *
- * GRAPH TOPOLOGY GENERATORS
- *
- *******************************************************************************/
+# pragma once
+
+// STL
+#include <utility> /* std::make_pair */
+
+// GRAYBAT
+#include <graybat/graphPolicy/Traits.hpp>
+
 
 namespace graybat {
 
     namespace pattern {
 
-	typedef unsigned                                                        VertexID;
-	typedef std::pair<VertexID, VertexID>                                   EdgeDescription;
-	typedef std::pair<std::vector<VertexID>, std::vector<EdgeDescription> > GraphDescription;
-
-    
+        template <typename T_GraphPolicy>
 	struct Ring {
 
-	    const unsigned verticesCount;
+            using GraphPolicy       = T_GraphPolicy;
+            using VertexDescription = graybat::graphPolicy::VertexDescription<GraphPolicy>;
+            using EdgeDescription   = graybat::graphPolicy::EdgeDescription<GraphPolicy>;
+            using GraphDescription  = graybat::graphPolicy::GraphDescription<GraphPolicy>;
+            using EdgeProperty      = graybat::graphPolicy::EdgeProperty<GraphPolicy>;
+            using VertexProperty    = graybat::graphPolicy::VertexProperty<GraphPolicy>;            
+
+            const unsigned verticesCount;
 
 	    Ring(const unsigned verticesCount) :
 		verticesCount(verticesCount) {
@@ -24,16 +30,20 @@ namespace graybat {
     
 
 	    GraphDescription operator()(){
-		std::vector<VertexID> vertices(verticesCount);
+		std::vector<VertexDescription> vertices(verticesCount);
 		std::vector<EdgeDescription> edges;
 
+                for(unsigned i = 0; i < vertices.size(); ++i){
+                    vertices.at(i) = std::make_pair(i, VertexProperty());
+                }
+                
 		if(vertices.size() != 1) {
 		    for(unsigned i = 0; i < vertices.size(); ++i){
 			if(i == vertices.size() - 1){
-			    edges.push_back(std::make_pair(i, 0));
+			    edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[0].first), EdgeProperty()));
 			}
 			else {
-			    edges.push_back(std::make_pair(i, i + 1));
+			    edges.push_back(std::make_pair(std::make_pair(vertices[i].first, vertices[i + 1].first), EdgeProperty()));
 			}
 		
 		    }

--- a/test/CageUT.cpp
+++ b/test/CageUT.cpp
@@ -101,6 +101,7 @@ BOOST_AUTO_TEST_CASE( send_recv ){
     hana::for_each(cages, [](auto cageRef){
 	    // Test setup
             using Cage    = typename decltype(cageRef)::type;
+            using GP      = typename Cage::GraphPolicy;
 	    using Event   = typename Cage::Event;
 	    using Vertex  = typename Cage::Vertex;
 	    using Edge    = typename Cage::Edge;
@@ -110,7 +111,7 @@ BOOST_AUTO_TEST_CASE( send_recv ){
     		const unsigned nElements = 1000;
 
 		auto& cage = cageRef.get();
-		cage.setGraph(graybat::pattern::FullyConnected(cage.getPeers().size()));
+		cage.setGraph(graybat::pattern::FullyConnected<GP>(cage.getPeers().size()));
 		cage.distribute(graybat::mapping::Roundrobin());
     
 		for(unsigned run_i = 0; run_i < nRuns; ++run_i){
@@ -244,6 +245,7 @@ BOOST_AUTO_TEST_CASE( asyncSend_recv ){
     hana::for_each(cages, [](auto cageRef){
 	    // Test setup
             using Cage    = typename decltype(cageRef)::type;
+            using GP      = typename Cage::GraphPolicy;            
 	    using Event   = typename Cage::Event;
 	    using Vertex  = typename Cage::Vertex;
 	    using Edge    = typename Cage::Edge;
@@ -253,7 +255,7 @@ BOOST_AUTO_TEST_CASE( asyncSend_recv ){
 
 		auto& cage = cageRef.get();                
     
-		cage.setGraph(graybat::pattern::FullyConnected(cage.getPeers().size()));
+		cage.setGraph(graybat::pattern::FullyConnected<GP>(cage.getPeers().size()));
 		cage.distribute(graybat::mapping::Consecutive());
 
 		const unsigned nElements = 1000;

--- a/test/EdgeUT.cpp
+++ b/test/EdgeUT.cpp
@@ -53,7 +53,8 @@ auto cages = hana::make_tuple(std::ref(zmqCage),
 BOOST_AUTO_TEST_CASE( send_recv ){
         hana::for_each(cages, [](auto cageRef){
 	    // Test setup
-            using Cage    = typename decltype(cageRef)::type;            
+            using Cage    = typename decltype(cageRef)::type;
+            using GP      = typename Cage::GraphPolicy;            
 	    using Event   = typename Cage::Event;
 	    using Vertex  = typename Cage::Vertex;
 	    using Edge    = typename Cage::Edge;
@@ -64,8 +65,8 @@ BOOST_AUTO_TEST_CASE( send_recv ){
 		std::vector<Event> events;
                 auto& grid = cageRef.get();
  
-		grid.setGraph(graybat::pattern::Grid(grid.getPeers().size(),
-						     grid.getPeers().size()));
+		grid.setGraph(graybat::pattern::Grid<GP>(grid.getPeers().size(),
+                                                         grid.getPeers().size()));
 		
 		grid.distribute(graybat::mapping::Consecutive());
 

--- a/test/VertexUT.cpp
+++ b/test/VertexUT.cpp
@@ -52,7 +52,8 @@ auto cages = hana::make_tuple(std::ref(zmqCage),
 BOOST_AUTO_TEST_CASE( spread_collect ){
     hana::for_each(cages, [](auto cageRef){
 	    // Test setup
-            using Cage    = typename decltype(cageRef)::type;            
+            using Cage    = typename decltype(cageRef)::type;
+            using GP      = typename Cage::GraphPolicy;
 	    using Event   = typename Cage::Event;
 	    using Vertex  = typename Cage::Vertex;
 
@@ -62,8 +63,8 @@ BOOST_AUTO_TEST_CASE( spread_collect ){
 		std::vector<Event> events;
                 auto& grid = cageRef.get();
 
-		grid.setGraph(graybat::pattern::Grid(grid.getPeers().size(),
-						     grid.getPeers().size()));
+		grid.setGraph(graybat::pattern::Grid<GP>(grid.getPeers().size(),
+                                                         grid.getPeers().size()));
 		
 		grid.distribute(graybat::mapping::Consecutive());
     
@@ -104,7 +105,8 @@ BOOST_AUTO_TEST_CASE( spread_collect ){
 BOOST_AUTO_TEST_CASE( accumulate ){
     hana::for_each(cages, [](auto cageRef){
 	    // Test setup
-            using Cage    = typename decltype(cageRef)::type;            
+            using Cage    = typename decltype(cageRef)::type;
+            using GP      = typename Cage::GraphPolicy;            
 	    using Event   = typename Cage::Event;
 	    using Vertex  = typename Cage::Vertex;
 
@@ -114,8 +116,8 @@ BOOST_AUTO_TEST_CASE( accumulate ){
 		std::vector<Event> events;
                 auto& grid = cageRef.get();
                 
-		grid.setGraph(graybat::pattern::Grid(grid.getPeers().size(),
-						     grid.getPeers().size()));
+		grid.setGraph(graybat::pattern::Grid<GP>(grid.getPeers().size(),
+                                                         grid.getPeers().size()));
 		
 		grid.distribute(graybat::mapping::Consecutive());
     
@@ -151,7 +153,8 @@ BOOST_AUTO_TEST_CASE( accumulate ){
 BOOST_AUTO_TEST_CASE( forward ){
     hana::for_each(cages, [](auto cageRef){
 	    // Test setup
-            using Cage    = typename decltype(cageRef)::type;            
+            using Cage    = typename decltype(cageRef)::type;
+            using GP      = typename Cage::GraphPolicy;            
 	    using Event   = typename Cage::Event;
 	    using Vertex  = typename Cage::Vertex;
 
@@ -161,7 +164,7 @@ BOOST_AUTO_TEST_CASE( forward ){
 		std::vector<Event> events;
                 auto& chain = cageRef.get();
                 
-		chain.setGraph(graybat::pattern::Chain(chain.getPeers().size()));
+		chain.setGraph(graybat::pattern::Chain<GP>(chain.getPeers().size()));
 		chain.distribute(graybat::mapping::Consecutive());
     
 		const unsigned nElements = 100;


### PR DESCRIPTION
Introduces `graybat::mapping::Filter` which tells graybat that the peer does only wants to host vertices with the provided tag. This mapping can be used when a peer wants to take a particular role in the
programm.
- Fixes #54 
- Example in `example/chain.cpp`
- Hint at @fabian-jung 
