### PR TITLE
Separate ZMQ from ZMQ independent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,14 +35,14 @@ if(${CXX_COMPILER_IS_G++})
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpedantic")      
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+  #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
 endif(${CXX_COMPILER_IS_G++})
 
 if(${CXX_COMPILER_IS_CLANG++})
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wpedantic")    
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+  #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
 endif(${CXX_COMPILER_IS_CLANG++})
 
 ###############################################################################
@@ -62,6 +62,12 @@ endif(CCACHE_FOUND)
 file(GLOB TESTS test/*.cpp)
 add_executable(check EXCLUDE_FROM_ALL ${TESTS})
 target_link_libraries(check ${LIBS})
+
+# Fast testing
+file(GLOB TESTSFAST test/UT.cpp test/CommunicationPolicyUT.cpp)
+add_executable(checkFast EXCLUDE_FROM_ALL ${TESTSFAST})
+target_link_libraries(checkFast ${LIBS})
+
 
 # Examples
 add_custom_target(example)

--- a/include/graybat/communicationPolicy/Base.hpp
+++ b/include/graybat/communicationPolicy/Base.hpp
@@ -214,7 +214,30 @@ namespace graybat {
 	     *        
 	     */
             void synchronize(const Context context);
+	    /** @} */
+
+
+            /***********************************************************************//**
+             *
+	     * @name Context Interface
+	     *
+	     * @{
+	     *
+	     ***************************************************************************/
+
+	    /**
+	     * @brief Returns a subcontext of *oldContext* with all peers that want to participate.
+             *        Peers which do not want to participate retrieve an invalid context.
+	     */
+            Context splitContext(const bool isMember, const Context oldContext) = delete;
+
+	    /**
+	     * @brief Returns the context that contains all peers
+	     */
+	    Context getGlobalContext() = delete;            
+
 	    /** @} */            
+            
             
         };
 

--- a/include/graybat/communicationPolicy/Traits.hpp
+++ b/include/graybat/communicationPolicy/Traits.hpp
@@ -25,9 +25,20 @@ namespace graybat {
 
         template <typename T_CommunicationPolicy>        
         using ContextID = unsigned;
-
-        template <typename T_CommunicationPolicy>        
-        using MsgType = unsigned;
+        
+        enum class MsgTypeType : std::int8_t { VADDR_REQUEST = 0,
+                VADDR_LOOKUP = 1,
+                DESTRUCT = 2,
+                RETRY = 3,
+                ACK = 4,
+                CONTEXT_INIT = 5,
+                CONTEXT_REQUEST = 6,
+                PEER = 7,
+                CONFIRM = 8,
+                SPLIT = 9};
+        
+        template <typename T_CommunicationPolicy>
+        using MsgType = MsgTypeType;
 
         template <typename T_CommunicationPolicy>        
         using MsgID = unsigned;
@@ -39,7 +50,7 @@ namespace graybat {
         using Event = typename traits::EventType<T_CommunicationPolicy>::type;
 
         template <typename T_CommunicationPolicy>
-        using Config = typename traits::ConfigType<T_CommunicationPolicy>::type;        
+        using Config = typename traits::ConfigType<T_CommunicationPolicy>::type;
         
     } // namespace communicationPolicy
     

--- a/include/graybat/communicationPolicy/ZMQ.hpp
+++ b/include/graybat/communicationPolicy/ZMQ.hpp
@@ -12,25 +12,18 @@
 #include <exception>  /* std::out_of_range */
 #include <sstream>    /* std::stringstream, std::istringstream */
 #include <string>     /* std::string */
-#include <queue>      /* std::queue */
-#include <utility>    /* std::move */
-#include <thread>     /* std::thread */
-#include <mutex>      /* std::mutex */
 
 // ZMQ
 #include <zmq.hpp>    /* zmq::socket_t, zmq::context_t */
 
-// HANA
-#include <boost/hana.hpp>
-namespace hana = boost::hana;
-
 // GrayBat
-#include <graybat/utils/MultiKeyMap.hpp>               /* utils::MultiKeyMap */
-#include <graybat/communicationPolicy/Base.hpp>        /* Base */
+#include <graybat/communicationPolicy/socket/Base.hpp> /* Base */
+#include <graybat/communicationPolicy/Traits.hpp>
+#include <graybat/communicationPolicy/zmq/Message.hpp> /* Message */
 #include <graybat/communicationPolicy/zmq/Context.hpp> /* Context */
 #include <graybat/communicationPolicy/zmq/Event.hpp>   /* Event */
 #include <graybat/communicationPolicy/zmq/Config.hpp>  /* Config */
-#include <graybat/communicationPolicy/Traits.hpp>
+
 
 namespace graybat {
     
@@ -62,242 +55,125 @@ namespace graybat {
                 using type = graybat::communicationPolicy::zmq::Config;
             };
 
+            
         }
 
-	struct ZMQ : public graybat::communicationPolicy::Base<ZMQ> {
+        namespace socket {
+
+            namespace traits {
+
+                template<>
+                struct UriType<ZMQ> {
+                    using type = std::string;
+                };
+
+                template<>
+                struct SocketType<ZMQ> {
+                    using type = ::zmq::socket_t;
+                };
+
+                template<>
+                struct MessageType<ZMQ> {
+                    using type = graybat::communicationPolicy::zmq::Message<ZMQ>;
+                };
+                
+            }
+            
+        }
+
+	struct ZMQ : public graybat::communicationPolicy::socket::Base<ZMQ> {
             
 	    // Type defs
-            using Tag       = typename graybat::communicationPolicy::Tag<ZMQ>;
-            using ContextID = typename graybat::communicationPolicy::ContextID<ZMQ>;
-            using MsgType   = typename graybat::communicationPolicy::MsgType<ZMQ>;
-            using MsgID     = typename graybat::communicationPolicy::MsgID<ZMQ>;
-            using VAddr     = typename graybat::communicationPolicy::VAddr<ZMQ>;
-            using Context   = typename graybat::communicationPolicy::Context<ZMQ>;
-            using Event     = typename graybat::communicationPolicy::Event<ZMQ>;
-            using Config    = typename graybat::communicationPolicy::Config<ZMQ>;            
-	    using Uri       = std::string;            
+            using Tag        = graybat::communicationPolicy::Tag<ZMQ>;
+            using ContextID  = graybat::communicationPolicy::ContextID<ZMQ>;
+            using MsgID      = graybat::communicationPolicy::MsgID<ZMQ>;
+            using VAddr      = graybat::communicationPolicy::VAddr<ZMQ>;
+            using Context    = graybat::communicationPolicy::Context<ZMQ>;
+            using Event      = graybat::communicationPolicy::Event<ZMQ>;
+            using Config     = graybat::communicationPolicy::Config<ZMQ>;
+            using MsgType    = graybat::communicationPolicy::MsgType<ZMQ>;
+            using Uri        = graybat::communicationPolicy::socket::Uri<ZMQ>;
+            using Socket     = graybat::communicationPolicy::socket::Socket<ZMQ>;            
+            using Message    = graybat::communicationPolicy::socket::Message<ZMQ>;
+            using SocketBase = graybat::communicationPolicy::socket::Base<ZMQ>;
             
-	    // Message types for signaling server
-            static const MsgType VADDR_REQUEST   = 0;
-            static const MsgType VADDR_LOOKUP    = 1;
-            static const MsgType DESTRUCT        = 2;
-            static const MsgType RETRY           = 3;
-            static const MsgType ACK             = 4;
-	    static const MsgType CONTEXT_INIT    = 5;
-	    static const MsgType CONTEXT_REQUEST = 6;	    
-
-	    // Message types between peers
-	    static const MsgType PEER            = 7;
-	    static const MsgType CONFIRM         = 8;
-	    static const MsgType SPLIT           = 9;	    
-            
-	    // zmq related
+	    // ZMQ Sockets
             ::zmq::context_t zmqContext;
-	    ::zmq::context_t zmqSignalingContext;
-            ::zmq::socket_t  recvSocket;
-	    ::zmq::socket_t  signalingSocket;
-	    const int zmqHwm;
-
-	    // policy related
-	    Context initialContext;
-            std::map<ContextID, std::map<VAddr, std::size_t> >sendSocketMappings;
-	    std::vector<::zmq::socket_t> sendSockets;
-            std::map<ContextID, std::map<VAddr, Uri> >phoneBook;
-            std::map<ContextID, std::map<Uri, VAddr> >inversePhoneBook;	    
-	    std::map<ContextID, Context> contexts;
-
-	    utils::MessageBox<::zmq::message_t, MsgType, ContextID, VAddr, Tag> inBox;
-	    
-	    unsigned maxMsgID;
-            std::thread recvHandler;
-            std::mutex sendMtx;
-            std::mutex recvMtx;	    
+            Socket signalingSocket;     
+            Socket recvSocket;
+            std::vector<Socket> sendSockets;
             
             // Uris
-            const Uri masterUri;
 	    const Uri peerUri;
-	    
+
+            // Construct
 	    ZMQ(Config const config) :
-		
 		zmqContext(1),
-		zmqSignalingContext(1),
                 recvSocket(zmqContext, ZMQ_PULL),
-		signalingSocket(zmqSignalingContext, ZMQ_REQ),
-		zmqHwm(10000),
-                inBox(config.maxBufferSize),
-		maxMsgID(0),
-                masterUri(config.masterUri),
-		peerUri(bindToNextFreePort(recvSocket, config.peerUri)){
+		signalingSocket(zmqContext, ZMQ_REQ),
+                peerUri(bindToNextFreePort(recvSocket, config.peerUri)),
+                SocketBase(config) {
 
-		// Connect to signaling process
-		signalingSocket.connect(masterUri.c_str());
-
-		// Retrieve Context id for initial context from signaling process
-		ContextID contextID = getInitialContextID(signalingSocket, config.contextSize);
-		    
-		// Retrieve own vAddr from signaling process for initial context
-		VAddr vAddr = getVAddr(signalingSocket, contextID, peerUri);
-		initialContext = Context(contextID, vAddr, config.contextSize);
-		contexts[initialContext.getID()] = initialContext;
-
-		// Retrieve for uris of other peers from signaling process for the initial context
-		for(unsigned vAddr = 0; vAddr < initialContext.size(); vAddr++){
-		    Uri remoteUri = getUri(signalingSocket, initialContext.getID(), vAddr);
-		    phoneBook[initialContext.getID()][vAddr] = remoteUri;
-		    inversePhoneBook[initialContext.getID()][remoteUri] = vAddr;
-		}
-
-		// Create socket connection to other peers
-		// Create socketmapping from initial context to sockets of VAddrs
-		for(unsigned vAddr = 0; vAddr < initialContext.size(); vAddr++){
-		    sendSockets.emplace_back(::zmq::socket_t(zmqContext, ZMQ_PUSH));
-		    sendSocketMappings[initialContext.getID()][vAddr] = sendSockets.size() - 1;
-		    sendSockets.at(sendSocketMappings[initialContext.getID()].at(vAddr)).connect(phoneBook[initialContext.getID()].at(vAddr).c_str());
-		}
-
-		// Create thread which recv all messages to this peer
-		recvHandler = std::thread(&ZMQ::handleRecv, this);
-
-	    }
-
-	    ZMQ(ZMQ &&other) = delete;
-	    ZMQ(ZMQ &other)  = delete;
+                //std::cout << "PeerUri: " << peerUri << std::endl;
+                SocketBase::init();
+                
+            }
 
 	    // Destructor
 	    ~ZMQ(){
-                // Send exit to signaling server
-                s_send(signalingSocket, std::to_string(DESTRUCT).c_str());
-
-                // Send exit to receive handler
-                std::array<unsigned, 1>  null;
-                asyncSendImpl(DESTRUCT, 0, initialContext, initialContext.getVAddr(), 0, null);
-                recvHandler.join();
-
-		//std::cout << "Destruct ZMQ" << std::endl;
-
+                SocketBase::deinit();
 	    }
+            
+	    ZMQ(ZMQ &&other) = delete;
+	    ZMQ(ZMQ &other)  = delete;
+
 
 	    /***********************************************************************//**
              *
-	     * @name ZMQ Utility functions
+	     * @name Socket base utilities
 	     *
 	     * @{
 	     *
 	     ***************************************************************************/
 
-	    ContextID getInitialContextID(::zmq::socket_t &socket, const size_t contextSize){
-		ContextID contextID = 0;
-		// Send vAddr request
-		std::stringstream ss;
-		ss << CONTEXT_INIT << " " << contextSize;
-		s_send(socket, ss.str().c_str());
+            void createSocketsToPeers(){
+		for(unsigned vAddr = 0; vAddr < initialContext.size(); vAddr++){
+		    sendSockets.emplace_back(Socket(zmqContext, ZMQ_PUSH));
+                }
+            }
+            
+            template <typename T_Socket>
+            void connectToSocket(T_Socket& socket, std::string const signalingUri) {
+                socket.connect(signalingUri.c_str());
+                    
+            }
 
-		// Recv vAddr
-		std::stringstream sss;
-		sss << s_recv(socket);
-		sss >> contextID;
-		return contextID;
-
-	    }
-
-	    ContextID getContextID(::zmq::socket_t &socket){
-		ContextID contextID = 0;
-
-		// Send vAddr request
-		std::stringstream ss;
-		ss << CONTEXT_REQUEST;
-		s_send(socket, ss.str().c_str());
-
-		// Recv vAddr
-		std::stringstream sss;
-		sss << s_recv(socket);
-		sss >> contextID;
-		return contextID;
-
-	    }
-
-	    VAddr getVAddr(::zmq::socket_t &socket, const ContextID contextID, const Uri uri){
-		VAddr vAddr(0);
-		// Send vAddr request
-		std::stringstream ss;
-		ss << VADDR_REQUEST << " " << contextID << " " << uri << " ";
-		s_send(socket, ss.str().c_str());
-
-		// Recv vAddr
-		std::stringstream sss;
-		sss << s_recv(socket);
-		sss >> vAddr;
-
-		return vAddr;
-                        
-	    }	    
-
-	    Uri getUri(::zmq::socket_t &socket, const ContextID contextID, const VAddr vAddr){
-		MsgType type = RETRY;
-                            
-		while(type == RETRY){
-		    // Send vAddr lookup
-		    std::stringstream ss;
-		    ss << VADDR_LOOKUP << " " << contextID << " " << vAddr;
-		    s_send(socket, ss.str().c_str());
-
-		    // Recv uri
-		    std::string remoteUri;
-		    std::stringstream sss;
-		    sss << s_recv(socket);
-		    sss >> type;
-		    if(type == ACK){
-			sss >> remoteUri;   
-			return remoteUri;
-		    }
-
-		}
-
-	    }
-
-	    MsgID getMsgID(){
-		return maxMsgID++;
-	    }
-	    
-	    static char * s_recv (::zmq::socket_t& socket) {
-		::zmq::message_t message(256);
+            template <typename T_Socket>            
+	    void recvFromSocket(T_Socket& socket, std::stringstream& ss) {
+		::zmq::message_t message;                
 		socket.recv(&message);
-		if (message.size() == static_cast<size_t>(-1))
-		    return NULL;
-		if (message.size() > 255)
-		    static_cast<char*>(message.data())[255] = 0;
-		return strdup (static_cast<char*>(message.data()));
+                ss << static_cast<char*>(message.data());
 	    }
 
-	    static int s_send (::zmq::socket_t& socket, const char *string) {
-		::zmq::message_t message(sizeof(char) * strlen(string));
-		memcpy (static_cast<char*>(message.data()), string, sizeof(char) * strlen(string));
+            template <typename T_Socket>            
+	    void recvFromSocket(T_Socket& socket, Message & message) {
+                socket.recv(&message.getMessage());                
+	    }
+
+            template <typename T_Socket>
+	    void sendToSocket(T_Socket& socket, std::stringstream const & ss) {
+                std::string string = ss.str();
+		::zmq::message_t message(sizeof(char) * string.size());
+		memcpy (static_cast<char*>(message.data()), string.data(), sizeof(char) * string.size());
 		socket.send(message);
-		return 0;
 	    }
 
-	    template <typename T_Data>
-	    void zmqMessageToData(::zmq::message_t &message, T_Data& data){
-		size_t    msgOffset = 0;
-		MsgType   remoteMsgType;
-		MsgID     remoteMsgID;
-		ContextID remoteContextID;
-		VAddr     remoteVAddr;
-		Tag       remoteTag;
-			 
-		memcpy (&remoteMsgType,    static_cast<char*>(message.data()) + msgOffset, sizeof(MsgType));   msgOffset += sizeof(MsgType);
-		memcpy (&remoteMsgID,      static_cast<char*>(message.data()) + msgOffset, sizeof(MsgID));     msgOffset += sizeof(MsgID);
-		memcpy (&remoteContextID,  static_cast<char*>(message.data()) + msgOffset, sizeof(ContextID)); msgOffset += sizeof(ContextID);
-		memcpy (&remoteVAddr,      static_cast<char*>(message.data()) + msgOffset, sizeof(VAddr));     msgOffset += sizeof(VAddr);
-		memcpy (&remoteTag,        static_cast<char*>(message.data()) + msgOffset, sizeof(Tag));       msgOffset += sizeof(Tag);
+            template <typename T_Socket>
+	    void sendToSocket(T_Socket& socket, ::zmq::message_t & data) {
+                socket.send(data);
+            }
 
-		memcpy (static_cast<void*>(data.data()),
-			static_cast<char*>(message.data()) + msgOffset,
-			sizeof(typename T_Data::value_type) * data.size());
-                        
-	    }
-
-	    Uri bindToNextFreePort(::zmq::socket_t &socket, const std::string peerUri){
+	    Uri bindToNextFreePort(Socket &socket, const std::string peerUri){
 		std::string peerBaseUri = peerUri.substr(0, peerUri.rfind(":"));
 		unsigned peerBasePort   = std::stoi(peerUri.substr(peerUri.rfind(":") + 1));		
 		bool connected          = false;
@@ -320,335 +196,7 @@ namespace graybat {
 		
             }
                 
-            void handleRecv(){
-
-                while(true){
-
-                    ::zmq::message_t message;
-                    recvSocket.recv(&message);
-
-                    {
-                        size_t    msgOffset = 0;
-                        MsgType   remoteMsgType;
-                        MsgID     remoteMsgID;
-                        ContextID remoteContextID;
-                        VAddr     remoteVAddr;
-                        Tag       remoteTag;
-
-                        memcpy (&remoteMsgType,    static_cast<char*>(message.data()) + msgOffset, sizeof(MsgType));   msgOffset += sizeof(MsgType);
-                        memcpy (&remoteMsgID,      static_cast<char*>(message.data()) + msgOffset, sizeof(MsgID));     msgOffset += sizeof(MsgID);
-                        memcpy (&remoteContextID,  static_cast<char*>(message.data()) + msgOffset, sizeof(ContextID)); msgOffset += sizeof(ContextID);
-                        memcpy (&remoteVAddr,      static_cast<char*>(message.data()) + msgOffset, sizeof(VAddr));     msgOffset += sizeof(VAddr);
-                        memcpy (&remoteTag,        static_cast<char*>(message.data()) + msgOffset, sizeof(Tag));       msgOffset += sizeof(Tag);
-
-			//std::cout << "recv handler: " << remoteMsgType << " " << remoteMsgID << " " << remoteContextID << " " << remoteVAddr << " " << remoteTag << std::endl;
-			
-                        if(remoteMsgType == DESTRUCT){
-                            return;
-                        }
-
-			if(remoteMsgType == PEER){
-                            std::array<unsigned,0>  null;
-			    Context context = contexts.at(remoteContextID);
-                            asyncSendImpl(CONFIRM, remoteMsgID, context, remoteVAddr, remoteTag, null);
-			}
-			
-                        inBox.enqueue(std::move(message), remoteMsgType, remoteContextID, remoteVAddr, remoteTag);
-
-                    }
-
-                }
-
-            }
-
-
-	    /** @} */
-
-            
-	    /***********************************************************************//**
-             *
-	     * @name Point to Point Communication Interface
-	     *
-	     * @{
-	     *
-	     ***************************************************************************/
-
-
-	    /**
-	     * @brief Blocking transmission of a message sendData to peer with virtual address destVAddr.
-	     * 
-	     * @param[in] destVAddr  VAddr of peer that will receive the message
-	     * @param[in] tag        Description of the message to better distinguish messages types
-	     * @param[in] context    Context in which both sender and receiver are included
-	     * @param[in] sendData   Data reference of template type T will be send to receiver peer.
-	     *                       T need to provide the function data(), that returns the pointer
-	     *                       to the data memory address. And the function size(), that
-	     *                       return the amount of data elements to send. Notice, that
-	     *                       std::vector and std::array implement this interface.
-	     */
-	    template <typename T_Send>
-	    void send(const VAddr destVAddr, const Tag tag, const Context context, const T_Send& sendData){
-                Event e = asyncSend(destVAddr, tag, context, sendData);
-                e.wait();
-	    }
-
-	    /** 
-	     * @brief Non blocking transmission of a message sendData to peer with virtual address destVAddr.
-	     * 
-	     * @param[in] destVAddr  VAddr of peer that will receive the message
-	     * @param[in] tag        Description of the message to better distinguish messages types
-	     * @param[in] context    Context in which both sender and receiver are included
-	     * @param[in] sendData   Data reference of template type T will be.
-	     *                       T need to provide the function data(), that returns the pointer
-	     *                       to the data memory address. And the function size(), that
-	     *                       return the amount of data elements to send. Notice, that
-	     *                       std::vector and std::array implement this interface.
-	     *
-	     * @return Event
-	     */
-	    template <typename T_Send>
-	    Event asyncSend(const VAddr destVAddr, const Tag tag, const Context context, T_Send& sendData){
-		//std::cout << "send method[" << context.getVAddr() << "]: " << context.getID() << " " << destVAddr << " " << tag << std::endl;
-		MsgID msgID = getMsgID();
-		asyncSendImpl(PEER, msgID, context, destVAddr, tag, sendData);
-                return Event(msgID, context, destVAddr, tag, *this);
-
-	    }
-
-            
-            template <typename T_Send>
-	    void asyncSendImpl(const MsgType msgType, const MsgID msgID, const Context context, const VAddr destVAddr, const Tag tag, T_Send& sendData){
-                // Create message
-                ::zmq::message_t message(sizeof(MsgType) +
-                                         sizeof(MsgID) +
-                                         sizeof(ContextID) +
-                                         sizeof(VAddr) +
-                                         sizeof(Tag) +
-                                         sendData.size() * sizeof(typename T_Send::value_type));
-
-                size_t    msgOffset(0);
-                ContextID contextID(context.getID());
-                VAddr     srcVAddr(context.getVAddr());
-		memcpy (static_cast<char*>(message.data()) + msgOffset, &msgType,        sizeof(MsgType));   msgOffset += sizeof(MsgType);
-		memcpy (static_cast<char*>(message.data()) + msgOffset, &msgID,          sizeof(MsgID));     msgOffset += sizeof(MsgID);		
-                memcpy (static_cast<char*>(message.data()) + msgOffset, &contextID,      sizeof(ContextID)); msgOffset += sizeof(ContextID);
-                memcpy (static_cast<char*>(message.data()) + msgOffset, &srcVAddr,       sizeof(VAddr));     msgOffset += sizeof(VAddr);
-                memcpy (static_cast<char*>(message.data()) + msgOffset, &tag,            sizeof(Tag));       msgOffset += sizeof(Tag);
-                memcpy (static_cast<char*>(message.data()) + msgOffset, sendData.data(), sizeof(typename T_Send::value_type) * sendData.size());
-
-                //std::cout << "[" << context.getVAddr() << "] sendImpl: " << msgType << " " << msgID << " " << context.getID() << " " << destVAddr << " " << tag << std::endl;
-		
-		std::size_t sendSocket_i  = sendSocketMappings.at(context.getID()).at(destVAddr);
-		::zmq::socket_t &sendSocket = sendSockets.at(sendSocket_i);
-
-		sendMtx.lock();
-		sendSocket.send(message);
-		sendMtx.unlock();
-
-            }
-
-
-	    /**
-	     * @brief Blocking receive of a message recvData from peer with virtual address srcVAddr.
-	     * 
-	     * @param[in]  srcVAddr   VAddr of peer that sended the message
-	     * @param[in]  tag        Description of the message to better distinguish messages types
-	     * @param[in]  context    Context in which both sender and receiver are included
-	     * @param[out] recvData   Data reference of template type T will be received from sender peer.
-	     *                        T need to provide the function data(), that returns the pointer
-	     *                        to the data memory address. And the function size(), that
-	     *                        return the amount of data elements to send. Notice, that
-	     *                        std::vector and std::array implement this interface.
-	     */
-	    template <typename T_Recv>
-            void recv(const VAddr srcVAddr, const Tag tag, const Context context, T_Recv& recvData){
-		//std::cout << "recv method[" << context.getVAddr() << "]:" << context.getID() << " " << srcVAddr << " " << tag << std::endl;
-		recvImpl(PEER, context, srcVAddr, tag, recvData);
-		
-	    }
-
-	    template <typename T_Recv>
-            Event recv(const Context context, T_Recv& recvData){
-		return recvImpl(context, recvData);
-	    }
-	    
-            template <typename T_Recv>
-            void recvImpl(const MsgType msgType, const Context context, const VAddr srcVAddr, const Tag tag, T_Recv& recvData){
-                //std::cout << "[" << context.getVAddr() << "] recvImpl: " << msgType << " " << context.getID() << " " << srcVAddr << " " << tag << std::endl;
-		::zmq::message_t message(std::move(inBox.waitDequeue(msgType, context.getID(), srcVAddr, tag)));
-		zmqMessageToData(message, recvData);
-		
-            }
-
-
-            template <typename T_Recv>
-            Event recvImpl(const Context context, T_Recv& recvData){
-
-		hana::tuple<MsgType, ContextID, VAddr, Tag>keys;
-		VAddr destVAddr;
-		Tag tag;
-
-		::zmq::message_t message(std::move(inBox.waitDequeue(keys, PEER, context.getID())));
-		destVAddr = hana::at(keys, hana::size_c<2>);
-		tag = hana::at(keys, hana::size_c<3>);
-
-		zmqMessageToData(message, recvData);
-		return Event(getMsgID(), context, destVAddr, tag, *this);
-		
-            }
-            
-            void wait(const MsgType msgID, const Context context, const VAddr vAddr, const Tag tag){
-		//std::cout << "wait method: " << msgID << " " << context.getID() << " " << vAddr << " " << tag << std::endl;
-                while(!ready(msgID, context, vAddr, tag));
-                      
-            }
-
-            bool ready(const MsgType msgID, const Context context, const VAddr vAddr, const Tag tag){
-
-                ::zmq::message_t message(std::move(inBox.waitDequeue(CONFIRM, context.getID(), vAddr, tag)));
-
-		size_t    msgOffset = 0;
-		MsgType   remoteMsgType;
-		MsgID     remoteMsgID;
-
-		memcpy (&remoteMsgType,    static_cast<char*>(message.data()) + msgOffset, sizeof(MsgType));   msgOffset += sizeof(MsgType);
-		memcpy (&remoteMsgID,      static_cast<char*>(message.data()) + msgOffset, sizeof(MsgID));     msgOffset += sizeof(MsgID);
-
-		if(remoteMsgID == msgID){
-		    return true;
-		}
-		else {
-		    inBox.enqueue(std::move(message), CONFIRM, context.getID(), vAddr, tag);
-		}
-
-                return false;
-		
-            }
-                
-
-
-            
-	    /** @} */
-    
-	    /************************************************************************//**
-	     *
-	     * @name Collective Communication Interface
-	     *
-	     * @{
-	     *
-	     **************************************************************************/
-	   
-    
-	    /*************************************************************************//**
-	     *
-	     * @name Context Interface
-	     *
-	     * @{
-	     *
-	     ***************************************************************************/
-	    /**
-	     * @todo peers of oldContext retain their vAddr in the newcontext
-	     *
-	     */
-	    Context splitContext(const bool isMember, const Context oldContext){
-		//std::cout  << oldContext.getVAddr() << " splitcontext entry" << std::endl;
-                ::zmq::message_t reqMessage;
-		Context newContext;
-
-                // Request old master for new context
-                std::array<unsigned, 1> member {{ isMember }};
-                ZMQ::asyncSendImpl(SPLIT, getMsgID(), oldContext, 0, 0, member);
-
-                // Peer with VAddr 0 collects new members
-                if( oldContext.getVAddr() == 0){
-                    std::array<unsigned, 2> nMembers {{ 0 }};
-                    std::vector<VAddr> vAddrs;
-                    
-                     for(unsigned vAddr = 0; vAddr < oldContext.size(); ++vAddr){
-                         std::array<unsigned, 1> remoteIsMember {{ 0 }};
-                         ZMQ::recvImpl(SPLIT, oldContext, vAddr, 0, remoteIsMember);
-
-                        if(remoteIsMember[0]) {
-                            nMembers[0]++;
-                            vAddrs.push_back(vAddr);
-			    
-                        }
-			
-                     }
-
-		    nMembers[1] = getContextID(signalingSocket);
-
-                    for(VAddr vAddr : vAddrs){
-                        ZMQ::asyncSendImpl(SPLIT, getMsgID(), oldContext, vAddr, 0, nMembers);
-			
-		    }
-		    
-		}
-
-		//std::cout << oldContext.getVAddr() << " check 0" << std::endl;
-		
-                 if(isMember){
-                    std::array<unsigned, 2> nMembers {{ 0 , 0 }};
-		    
-                    ZMQ::recvImpl(SPLIT, oldContext, 0, 0, nMembers);
-		    ContextID newContextID = nMembers[1];
-
-		    newContext = Context(newContextID, getVAddr(signalingSocket, newContextID, peerUri), nMembers[0]);
-		    contexts[newContext.getID()] = newContext;
-
-		    //std::cout  << oldContext.getVAddr() << " check 1" << std::endl;
-		    // Update phonebook for new context
-		    for(unsigned vAddr = 0; vAddr < newContext.size(); vAddr++){
-		 	Uri remoteUri = getUri(signalingSocket, newContext.getID(), vAddr);
-		    	phoneBook[newContext.getID()][vAddr] = remoteUri;
-		 	inversePhoneBook[newContext.getID()][remoteUri] = vAddr;
-		    }
-
-		    //std::cout  << oldContext.getVAddr() << " check 2" << std::endl;
-		    // Create mappings to sockets for new context
-		    for(unsigned vAddr = 0; vAddr < newContext.size(); vAddr++){
-		 	Uri uri = phoneBook[newContext.getID()][vAddr];
-		 	VAddr oldVAddr = inversePhoneBook[oldContext.getID()].at(uri);
-		 	sendSocketMappings[newContext.getID()][vAddr] = sendSocketMappings[oldContext.getID()].at(oldVAddr);
-		    }
-		    
-		 }
-		 else{
-		     // Invalid context for "not members"
-		     newContext = Context();
-		 }
-
-		 //std::cout  << oldContext.getVAddr() << " check 3" << std::endl;
-
-		 // Barrier thus recvHandler is up to date with sendSocketMappings
-		 // Necessary in environment with multiple zmq objects
-		 std::array<unsigned, 0> null;
-		 for(unsigned vAddr = 0; vAddr < oldContext.size(); ++vAddr){
-		     ZMQ::asyncSendImpl(SPLIT, getMsgID(), oldContext, vAddr, 0, null);
-		 }
-		 for(unsigned vAddr = 0; vAddr < oldContext.size(); ++vAddr){
-		     ZMQ::recvImpl(SPLIT, oldContext, vAddr, 0, null);
-		 }
-
-		 //std::cout  << oldContext.getVAddr() << " splitContext end" << std::endl;		 
-		return newContext;
-
-	    }
-
-	
-	    /**
-	     * @brief Returns the context that contains all peers
-	     *
-	     */
-	    Context getGlobalContext(){
-	     	return initialContext;
-	    }
-	    /** @} */
-
-	};
-
-
-        
+	}; // class ZMQ
 
     } // namespace communicationPolicy
 	

--- a/include/graybat/communicationPolicy/socket/Base.hpp
+++ b/include/graybat/communicationPolicy/socket/Base.hpp
@@ -1,0 +1,669 @@
+#pragma once
+
+// STL
+#include <string> /* std::string */
+#include <mutex>  /* std::mutex */
+#include <map>    /* std::map */
+#include <vector> /* std::vector */
+#include <thread> /* std::thread */
+
+// HANA
+#include <boost/hana.hpp>
+namespace hana = boost::hana;
+
+// GrayBat
+#include <graybat/communicationPolicy/Base.hpp>          /* graybat::communicationPolicy::Base */
+#include <graybat/communicationPolicy/Traits.hpp>        /* cp related types */
+#include <graybat/communicationPolicy/socket/Traits.hpp> /* socket related types */
+#include <graybat/utils/MultiKeyMap.hpp>                 /* utils::MessageBox */
+
+namespace graybat {
+
+    namespace communicationPolicy {
+
+        namespace socket {
+
+            template <typename T_CommunicationPolicy>            
+            struct Base : graybat::communicationPolicy::Base<T_CommunicationPolicy>{
+
+                // Types
+                using CommunicationPolicy = T_CommunicationPolicy;
+                using ContextID           = graybat::communicationPolicy::ContextID<CommunicationPolicy>;
+                using Context             = graybat::communicationPolicy::Context<CommunicationPolicy>;
+                using Tag                 = graybat::communicationPolicy::Tag<CommunicationPolicy>;
+                using VAddr               = graybat::communicationPolicy::VAddr<CommunicationPolicy>;
+                using MsgType             = graybat::communicationPolicy::MsgType<CommunicationPolicy>;
+                using MsgID               = graybat::communicationPolicy::MsgID<CommunicationPolicy>;
+                using Event               = graybat::communicationPolicy::Event<CommunicationPolicy>;
+                using Config              = graybat::communicationPolicy::Config<CommunicationPolicy>;
+                using Message             = graybat::communicationPolicy::socket::Message<CommunicationPolicy>;
+                using Uri                 = graybat::communicationPolicy::socket::Uri<CommunicationPolicy>;
+                using Socket              = graybat::communicationPolicy::socket::Socket<CommunicationPolicy>;
+
+                // Members
+                const Uri masterUri;
+                const size_t contextSize;
+                unsigned maxMsgID;                                
+                std::mutex sendMtx;
+                std::map<ContextID, std::map<VAddr, std::size_t> > sendSocketMappings;
+                utils::MessageBox<Message, MsgType, ContextID, VAddr, Tag> inBox;
+
+
+                std::map<ContextID, Context> contexts;
+
+                Context initialContext;
+                std::map<ContextID, std::map<VAddr, Uri> > phoneBook;
+                std::map<ContextID, std::map<Uri, VAddr> > inversePhoneBook;	    
+
+                std::thread recvHandler;
+                
+                // Construct/Destruct Methods
+                Base(Config const config);
+                
+                ~Base();
+
+                void init();
+                void deinit();
+
+                
+                // Socket Interface
+                template <typename T_Socket>
+                void connectToSocket(T_Socket& socket, std::string const signalingUri) = delete;
+
+                template <typename T_Socket>
+                void sendToSocket(T_Socket& socket, std::stringstream const ss) = delete;
+
+                template <typename T_Socket, typename T_Data>
+                void sendToSocket(T_Socket& socket, T_Data const data) = delete;
+                
+                template <typename T_Socket>
+                void recvFromSocket(T_Socket& socket, std::stringstream ss) = delete;
+
+                template <typename T_Socket>            
+                void recvFromSocket (T_Socket& socket, Message & message) = delete;
+
+                void createSocketsToPeers() = delete;
+
+                // P2P INTERFACE
+
+                /**
+                 * @brief Blocking transmission of a message sendData to peer with virtual address destVAddr.
+                 * 
+                 * @param[in] destVAddr  VAddr of peer that will receive the message
+                 * @param[in] tag        Description of the message to better distinguish messages types
+                 * @param[in] context    Context in which both sender and receiver are included
+                 * @param[in] sendData   Data reference of template type T will be send to receiver peer.
+                 *                       T need to provide the function data(), that returns the pointer
+                 *                       to the data memory address. And the function size(), that
+                 *                       return the amount of data elements to send. Notice, that
+                 *                       std::vector and std::array implement this interface.
+                 */
+                template <typename T_Send>
+                void send(const VAddr destVAddr, const Tag tag, const Context context, const T_Send& sendData);
+
+                /** 
+                 * @brief Non blocking transmission of a message sendData to peer with virtual address destVAddr.
+                 * 
+                 * @param[in] destVAddr  VAddr of peer that will receive the message
+                 * @param[in] tag        Description of the message to better distinguish messages types
+                 * @param[in] context    Context in which both sender and receiver are included
+                 * @param[in] sendData   Data reference of template type T will be.
+                 *                       T need to provide the function data(), that returns the pointer
+                 *                       to the data memory address. And the function size(), that
+                 *                       return the amount of data elements to send. Notice, that
+                 *                       std::vector and std::array implement this interface.
+                 *
+                 * @return Event
+                 */
+                template <typename T_Send>
+                Event asyncSend(const VAddr destVAddr, const Tag tag, const Context context, const T_Send& sendData);
+
+                /**
+                 * @brief Blocking receive of a message recvData from peer with virtual address srcVAddr.
+                 * 
+                 * @param[in]  srcVAddr   VAddr of peer that sended the message
+                 * @param[in]  tag        Description of the message to better distinguish messages types
+                 * @param[in]  context    Context in which both sender and receiver are included
+                 * @param[out] recvData   Data reference of template type T will be received from sender peer.
+                 *                        T need to provide the function data(), that returns the pointer
+                 *                        to the data memory address. And the function size(), that
+                 *                        return the amount of data elements to send. Notice, that
+                 *                        std::vector and std::array implement this interface.
+                 */
+                template <typename T_Recv>
+                void recv(const VAddr srcVAddr, const Tag tag, const Context context, T_Recv& recvData);
+
+                template <typename T_Recv>
+                Event recv(const Context context, T_Recv& recvData);
+
+                void wait(const MsgID msgID, const Context context, const VAddr vAddr, const Tag tag);
+
+                bool ready(const MsgID msgID, const Context context, const VAddr vAddr, const Tag tag);
+                
+                
+                // CONTEXT INTERFACE
+                Context getGlobalContext();
+
+                Context splitContext(const bool isMember, const Context oldContext);
+
+                                
+                // SIGNALING METHODS
+                template <typename T_Socket>
+                ContextID getInitialContextID(T_Socket& socket, size_t const contextSize);
+
+                template <typename T_Socket>                
+                ContextID getContextID(T_Socket& socket, size_t const size);
+
+                template <typename T_Socket>                
+                VAddr getVAddr(T_Socket &socket, ContextID const contextID, Uri const uri);
+
+                template <typename T_Socket>                                
+                Uri getUri(T_Socket& socket, ContextID const contextID, VAddr const vAddr);
+
+
+                // Auxilary
+                template <typename T_Send>
+                void asyncSendImpl(MsgType const msgType, MsgID const msgID, Context const context,VAddr const destVAddr, Tag const tag, T_Send & sendData);
+
+                template <typename T_Recv>
+                void recvImpl(MsgType const msgType, Context const context,VAddr const destVAddr, Tag const tag, T_Recv & recvData);
+
+                template <typename T_Recv>
+                Event recvImpl(Context const context, T_Recv & recvData);
+
+                MsgID getMsgID();
+
+                void handleRecv();
+                
+            };
+
+
+            template <typename T_CommunicationPolicy>            
+            Base<T_CommunicationPolicy>::Base(Config const config)  :
+                masterUri(config.masterUri),
+                contextSize(config.contextSize),
+                maxMsgID(0),
+                inBox(config.maxBufferSize){
+                
+            }
+
+            
+            template <typename T_CommunicationPolicy>
+            Base<T_CommunicationPolicy>::~Base() {
+                
+            }
+
+            template <typename T_CommunicationPolicy>            
+            auto Base<T_CommunicationPolicy>::init()
+                -> void {
+
+                // Connect to signaling process
+                static_cast<CommunicationPolicy*>(this)->connectToSocket(static_cast<CommunicationPolicy*>(this)->signalingSocket, masterUri);
+
+		// Retrieve Context id for initial context from signaling process
+		ContextID contextID = getInitialContextID(static_cast<CommunicationPolicy*>(this)->signalingSocket, contextSize);
+		    
+		// Retrieve own vAddr from signaling process for initial context
+		VAddr vAddr = getVAddr(static_cast<CommunicationPolicy*>(this)->signalingSocket, contextID, static_cast<CommunicationPolicy*>(this)->peerUri);
+		initialContext = Context(contextID, vAddr, contextSize);
+		contexts[initialContext.getID()] = initialContext;
+
+		// Retrieve for uris of other peers from signaling process for the initial context
+		for(unsigned vAddr = 0; vAddr < initialContext.size(); vAddr++){
+		    Uri remoteUri = getUri(static_cast<CommunicationPolicy*>(this)->signalingSocket, initialContext.getID(), vAddr);
+		    phoneBook[initialContext.getID()][vAddr] = remoteUri;
+		    inversePhoneBook[initialContext.getID()][remoteUri] = vAddr;
+		}
+
+		// Create socket connection to other peers
+		// Create socketmapping from initial context to sockets of VAddrs
+                static_cast<CommunicationPolicy*>(this)->createSocketsToPeers();
+                
+		for(unsigned vAddr = 0; vAddr < initialContext.size(); vAddr++){
+		    sendSocketMappings[initialContext.getID()][vAddr] = vAddr;
+                    static_cast<CommunicationPolicy*>(this)->connectToSocket(static_cast<CommunicationPolicy*>(this)->sendSockets.at(sendSocketMappings.at(initialContext.getID()).at(vAddr)), phoneBook.at(initialContext.getID()).at(vAddr).c_str());
+
+                    //std::cout << "sendSocket_i: " << vAddr << " --> " << phoneBook.at(initialContext.getID()).at(vAddr) << std::endl;
+
+                }
+
+                // Create thread which recv all messages to this peer
+                recvHandler = std::thread(&Base<CommunicationPolicy>::handleRecv, this);
+
+            }
+
+            template <typename T_CommunicationPolicy>            
+            auto Base<T_CommunicationPolicy>::deinit()
+                -> void {
+                std::stringstream ss;
+                ss << static_cast<size_t>(MsgType::DESTRUCT);
+                static_cast<CommunicationPolicy*>(this)->sendToSocket(static_cast<CommunicationPolicy*>(this)->signalingSocket, ss);
+
+                std::array<unsigned, 1>  null;
+                static_cast<CommunicationPolicy*>(this)->asyncSendImpl(MsgType::DESTRUCT, 0, initialContext, initialContext.getVAddr(), 0, null);
+                recvHandler.join();
+
+            }
+            
+            template <typename T_CommunicationPolicy>            
+            template <typename T_Send>
+            auto Base<T_CommunicationPolicy>::send(const graybat::communicationPolicy::VAddr<T_CommunicationPolicy> destVAddr,
+                                                      const graybat::communicationPolicy::Tag<T_CommunicationPolicy> tag,
+                                                      const graybat::communicationPolicy::Context<T_CommunicationPolicy> context,
+                                                      const T_Send& sendData)
+            -> void
+            {
+                using CommunicationPolicy = T_CommunicationPolicy;                
+                using Event               = graybat::communicationPolicy::Event<CommunicationPolicy>;
+                
+                Event e = asyncSend(destVAddr, tag, context, sendData);
+                e.wait();
+            }
+
+            template <typename T_CommunicationPolicy>
+            template <typename T_Send>
+            auto Base<T_CommunicationPolicy>::asyncSend(const graybat::communicationPolicy::VAddr<T_CommunicationPolicy> destVAddr,
+                                                           const graybat::communicationPolicy::Tag<T_CommunicationPolicy> tag,
+                                                           const graybat::communicationPolicy::Context<T_CommunicationPolicy> context,
+                                                           const T_Send& sendData)
+            -> graybat::communicationPolicy::Event<T_CommunicationPolicy>
+            {
+                using CommunicationPolicy = T_CommunicationPolicy;
+                using MsgType             = graybat::communicationPolicy::MsgType<CommunicationPolicy>;
+                using MsgID               = graybat::communicationPolicy::MsgID<CommunicationPolicy>;
+                using Event               = graybat::communicationPolicy::Event<CommunicationPolicy>;
+                
+                //std::cout << "send method[" << context.getVAddr() << "]: " << context.getID() << " " << destVAddr << " " << tag << std::endl;
+                MsgID msgID = getMsgID();
+                asyncSendImpl(MsgType::PEER, msgID, context, destVAddr, tag, sendData);
+                return Event(msgID, context, destVAddr, tag, *static_cast<CommunicationPolicy*>(this));
+
+            }
+
+            template <typename T_CommunicationPolicy>            
+            template <typename T_Recv>
+            auto Base<T_CommunicationPolicy>::recv(const graybat::communicationPolicy::VAddr<T_CommunicationPolicy> srcVAddr,
+                                                      const graybat::communicationPolicy::Tag<T_CommunicationPolicy> tag,
+                                                      const graybat::communicationPolicy::Context<T_CommunicationPolicy> context,
+                                                      T_Recv& recvData)
+            -> void
+            {
+                using CommunicationPolicy = T_CommunicationPolicy;
+                using MsgType             = graybat::communicationPolicy::MsgType<CommunicationPolicy>;
+                
+                //std::cout << "recv method[" << context.getVAddr() << "]:" << context.getID() << " " << srcVAddr << " " << tag << std::endl;
+                recvImpl(MsgType::PEER, context, srcVAddr, tag, recvData);
+		
+            }
+
+            
+            template <typename T_CommunicationPolicy>            
+            template <typename T_Recv>
+            auto Base<T_CommunicationPolicy>::recv(const graybat::communicationPolicy::Context<T_CommunicationPolicy> context,
+                                                      T_Recv& recvData)
+            -> graybat::communicationPolicy::Event<T_CommunicationPolicy>
+            {
+                return recvImpl(context, recvData);
+            }
+
+            template <typename T_CommunicationPolicy>            
+            auto Base<T_CommunicationPolicy>::wait(const graybat::communicationPolicy::MsgID<T_CommunicationPolicy> msgID,
+                                                      const graybat::communicationPolicy::Context<T_CommunicationPolicy> context,
+                                                      const graybat::communicationPolicy::VAddr<T_CommunicationPolicy> vAddr,
+                                                      const graybat::communicationPolicy::Tag<T_CommunicationPolicy> tag)
+            -> void
+            {
+
+                //std::cout << "wait method: " << msgID << " " << context.getID() << " " << vAddr << " " << tag << std::endl;
+                while(!ready(msgID, context, vAddr, tag));
+                      
+            }
+            
+            template <typename T_CommunicationPolicy>
+            auto Base<T_CommunicationPolicy>::ready(const graybat::communicationPolicy::MsgID<T_CommunicationPolicy> msgID,
+                                                      const graybat::communicationPolicy::Context<T_CommunicationPolicy> context,
+                                                      const graybat::communicationPolicy::VAddr<T_CommunicationPolicy> vAddr,
+                                                      const graybat::communicationPolicy::Tag<T_CommunicationPolicy> tag)
+            -> bool
+            {
+                using CommunicationPolicy = T_CommunicationPolicy;
+                using Message             = graybat::communicationPolicy::socket::Message<CommunicationPolicy>;
+                using MsgType             = graybat::communicationPolicy::MsgType<CommunicationPolicy>;                    
+                
+                Message message(std::move(inBox.waitDequeue(MsgType::CONFIRM, context.getID(), vAddr, tag)));
+
+                // size_t    msgOffset = 0;
+                // MsgType   remoteMsgType;
+                // MsgID     remoteMsgID;
+
+
+                if(message.getMsgID() == msgID){
+                    return true;
+                }
+                else {
+                    inBox.enqueue(std::move(message), MsgType::CONFIRM, context.getID(), vAddr, tag);
+                }
+
+                return false;
+		
+            }    
+
+            /*******************************************************************
+             *
+             ******************************************************************/
+            template <typename T_CommunicationPolicy>            
+            auto Base<T_CommunicationPolicy>::getGlobalContext()
+            -> graybat::communicationPolicy::Context<T_CommunicationPolicy> {
+                return initialContext;
+            }
+
+            
+            template <typename T_CommunicationPolicy>                        
+	    auto Base<T_CommunicationPolicy>::splitContext(const bool isMember,
+                                                              const graybat::communicationPolicy::Context<T_CommunicationPolicy> oldContext)
+                -> graybat::communicationPolicy::Context<T_CommunicationPolicy> {
+
+                using CommunicationPolicy = T_CommunicationPolicy;
+                using Context             = graybat::communicationPolicy::Context<CommunicationPolicy>;
+
+		//std::cout  << oldContext.getVAddr() << " splitcontext entry" << std::endl;
+                
+		Context newContext;
+                VAddr masterVAddr = 0;
+
+                // Request old master for new context
+                std::array<unsigned, 1> member {{ isMember }};
+                static_cast<CommunicationPolicy*>(this)->asyncSendImpl(MsgType::SPLIT, getMsgID(), oldContext, masterVAddr, 0, member);
+
+                // Peer with VAddr 0 collects new members
+                if( oldContext.getVAddr() == masterVAddr){
+                    std::array<unsigned, 2> nMembers {{ 0 }};
+                    std::vector<VAddr> vAddrs;
+                    
+                    for(unsigned vAddr = 0; vAddr < oldContext.size(); ++vAddr){
+                        std::array<unsigned, 1> remoteIsMember {{ 0 }};
+                        //std::cout << "Recv remoteIsMember: " <<  vAddr << std::endl;
+                        static_cast<CommunicationPolicy*>(this)->recvImpl(MsgType::SPLIT, oldContext, vAddr, 0, remoteIsMember);
+
+                        if(remoteIsMember[0]) {
+                            nMembers[0]++;
+                            vAddrs.push_back(vAddr);
+			    
+                        }
+			
+                    }
+
+		    nMembers[1] = getContextID(static_cast<CommunicationPolicy*>(this)->signalingSocket, nMembers[0]);
+
+                    for(VAddr vAddr : vAddrs){
+                        static_cast<CommunicationPolicy*>(this)->asyncSendImpl(MsgType::SPLIT, getMsgID(), oldContext, vAddr, 0, nMembers);
+			
+		    }
+		    
+		}
+
+		//std::cout << oldContext.getVAddr() << " check 0" << std::endl;
+		
+                if(isMember){
+                    std::array<unsigned, 2> nMembers {{ 0 , 0 }};
+		    
+                    static_cast<CommunicationPolicy*>(this)->recvImpl(MsgType::SPLIT, oldContext, 0, 0, nMembers);
+		    ContextID newContextID = nMembers[1];
+
+		    newContext = Context(newContextID, getVAddr(static_cast<CommunicationPolicy*>(this)->signalingSocket, newContextID, static_cast<CommunicationPolicy*>(this)->peerUri), nMembers[0]);
+		    contexts[newContext.getID()] = newContext;
+
+		    //std::cout  << oldContext.getVAddr() << " check 1" << std::endl;
+		    // Update phonebook for new context
+		    for(unsigned vAddr = 0; vAddr < newContext.size(); vAddr++){
+		 	Uri remoteUri = getUri(static_cast<CommunicationPolicy*>(this)->signalingSocket, newContext.getID(), vAddr);
+		    	phoneBook[newContext.getID()][vAddr] = remoteUri;
+		 	inversePhoneBook[newContext.getID()][remoteUri] = vAddr;
+                        
+                        
+		    }
+
+		    //std::cout  << oldContext.getVAddr() << " check 2" << std::endl;
+		    // Create mappings to sockets for new context
+		    for(unsigned vAddr = 0; vAddr < newContext.size(); vAddr++){
+		 	Uri uri = phoneBook.at(newContext.getID()).at(vAddr);
+		 	VAddr oldVAddr = inversePhoneBook.at(oldContext.getID()).at(uri);
+		 	sendSocketMappings[newContext.getID()][vAddr] = sendSocketMappings.at(oldContext.getID()).at(oldVAddr);
+
+		    }
+		    
+                }
+                else{
+                    // Invalid context for "not members"
+                    newContext = Context();
+                }
+
+                //std::cout  << oldContext.getVAddr() << " check 3" << std::endl;
+
+                // Barrier thus recvHandler is up to date with sendSocketMappings
+                // Necessary in environment with multiple zmq objects
+                std::array<unsigned, 0> null;
+                for(unsigned vAddr = 0; vAddr < oldContext.size(); ++vAddr){
+                    static_cast<CommunicationPolicy*>(this)->asyncSendImpl(MsgType::SPLIT, getMsgID(), oldContext, vAddr, 0, null);
+                }
+                for(unsigned vAddr = 0; vAddr < oldContext.size(); ++vAddr){
+                    static_cast<CommunicationPolicy*>(this)->recvImpl(MsgType::SPLIT, oldContext, vAddr, 0, null);
+                }
+
+                //std::cout  << oldContext.getVAddr() << " splitContext end" << std::endl;		 
+		return newContext;
+
+	    }
+            
+
+            template <typename T_CommunicationPolicy>
+            template <typename T_Socket>
+	    auto Base<T_CommunicationPolicy>::getInitialContextID(T_Socket& socket, size_t const contextSize)
+                -> graybat::communicationPolicy::ContextID<T_CommunicationPolicy> {
+		ContextID contextID = 0;
+		// Send vAddr request
+		std::stringstream ss;
+		ss << static_cast<size_t>(MsgType::CONTEXT_INIT) << " " << contextSize;
+                static_cast<CommunicationPolicy*>(this)->sendToSocket(socket, ss);
+
+		// Recv vAddr
+		std::stringstream sss;
+                static_cast<CommunicationPolicy*>(this)->recvFromSocket(socket, sss);                
+		sss >> contextID;
+		return contextID;
+
+	    }
+
+            
+            template <typename T_CommunicationPolicy>
+            template <typename T_Socket>
+            auto Base<T_CommunicationPolicy>::getContextID(T_Socket& socket, size_t const size)
+            -> graybat::communicationPolicy::ContextID<T_CommunicationPolicy> {
+                using ContextID = graybat::communicationPolicy::ContextID<T_CommunicationPolicy>;
+                
+		ContextID contextID = 0;
+
+		// Send vAddr request
+		std::stringstream ss;
+		ss << static_cast<size_t>(MsgType::CONTEXT_REQUEST) << " " << size;;
+
+                static_cast<CommunicationPolicy*>(this)->sendToSocket(socket, ss);                                
+
+		// Recv vAddr
+		std::stringstream sss;
+                static_cast<CommunicationPolicy*>(this)->recvFromSocket(socket, sss);                                
+		sss >> contextID;
+		return contextID;
+
+	    }
+
+            
+            template <typename T_CommunicationPolicy>
+            template <typename T_Socket>
+            auto Base<T_CommunicationPolicy>::getVAddr(T_Socket &socket, ContextID const contextID, Uri const uri)
+                -> graybat::communicationPolicy::VAddr<T_CommunicationPolicy> {
+
+                using VAddr = graybat::communicationPolicy::VAddr<T_CommunicationPolicy>;
+                
+		VAddr vAddr(0);
+		// Send vAddr request
+		std::stringstream ss;
+		ss << static_cast<size_t>(MsgType::VADDR_REQUEST) << " " << contextID << " " << uri << " ";
+                static_cast<CommunicationPolicy*>(this)->sendToSocket(socket, ss);         
+
+		// Recv vAddr
+		std::stringstream sss;
+                static_cast<CommunicationPolicy*>(this)->recvFromSocket(socket, sss);                
+		sss >> vAddr;
+
+		return vAddr;
+                        
+	    }	    
+
+            
+            template <typename T_CommunicationPolicy>
+            template <typename T_Socket>
+	    auto Base<T_CommunicationPolicy>::getUri(T_Socket& socket,
+                        graybat::communicationPolicy::ContextID<T_CommunicationPolicy> const contextID,
+                        graybat::communicationPolicy::VAddr<T_CommunicationPolicy> const vAddr)
+                -> graybat::communicationPolicy::socket::Uri<T_CommunicationPolicy> {
+                
+		MsgType type = MsgType::RETRY;
+                            
+		while(type == MsgType::RETRY){
+		    // Send vAddr lookup
+		    std::stringstream ss;
+		    ss << static_cast<size_t>(MsgType::VADDR_LOOKUP) << " " << contextID << " " << vAddr;
+                    static_cast<CommunicationPolicy*>(this)->sendToSocket(socket, ss);
+
+		    // Recv uri
+                    std::string msgTypeStr;
+		    std::string remoteUri;
+		    std::stringstream sss;
+                    static_cast<CommunicationPolicy*>(this)->recvFromSocket(socket, sss);                    
+		    sss >> msgTypeStr;
+                    type = static_cast<MsgType>(std::stoi(msgTypeStr));
+		    if(type == MsgType::ACK){
+			sss >> remoteUri;   
+			return remoteUri;
+                        
+		    }
+
+		}
+
+	    }
+
+
+            template <typename T_CommunicationPolicy>            
+            template <typename T_Send>
+	    auto Base<T_CommunicationPolicy>::asyncSendImpl(graybat::communicationPolicy::MsgType<T_CommunicationPolicy> const msgType,
+                                                               graybat::communicationPolicy::MsgID<T_CommunicationPolicy> const msgID,
+                                                               graybat::communicationPolicy::Context<T_CommunicationPolicy> const context,
+                                                               graybat::communicationPolicy::VAddr<T_CommunicationPolicy> const destVAddr,
+                                                               graybat::communicationPolicy::Tag<T_CommunicationPolicy> const tag,
+                                                               T_Send & sendData)
+            -> void {
+
+                using Message   = graybat::communicationPolicy::socket::Message<T_CommunicationPolicy>;
+
+                //std::cout << "send msg: " << static_cast<int>(msgType) << " " << msgID << " " << context.getID() << " " << destVAddr << "(socket_i " <<  sendSocketMappings.at(context.getID()).at(destVAddr)<< ") " << tag << std::endl;
+                
+                // Create message
+                Message message(msgType, msgID, context.getID(), context.getVAddr(), tag, sendData);                
+		
+	        std::size_t sendSocket_i  = sendSocketMappings.at(context.getID()).at(destVAddr);
+	        Socket &sendSocket = static_cast<CommunicationPolicy*>(this)->sendSockets.at(sendSocket_i);
+
+	        sendMtx.lock();
+                static_cast<CommunicationPolicy*>(this)->sendToSocket(sendSocket, message.getMessage());
+	        sendMtx.unlock();
+
+            }
+
+            template <typename T_CommunicationPolicy>
+            template <typename T_Recv>
+            auto Base<T_CommunicationPolicy>::recvImpl(graybat::communicationPolicy::MsgType<T_CommunicationPolicy> const msgType,
+                                                          graybat::communicationPolicy::Context<T_CommunicationPolicy> const context,
+                                                          graybat::communicationPolicy::VAddr<T_CommunicationPolicy> const srcVAddr,
+                                                          graybat::communicationPolicy::Tag<T_CommunicationPolicy> const tag,
+                                                          T_Recv& recvData)
+            -> void {
+
+                using Message   = graybat::communicationPolicy::socket::Message<T_CommunicationPolicy>;
+                
+		Message message(std::move(inBox.waitDequeue(msgType, context.getID(), srcVAddr, tag)));
+                memcpy (static_cast<void*>(recvData.data()),
+			static_cast<std::int8_t*>(message.getData()),
+			sizeof(typename T_Recv::value_type) * recvData.size());
+		
+            }
+
+            
+            template <typename T_CommunicationPolicy>
+            template <typename T_Recv>
+            auto Base<T_CommunicationPolicy>::recvImpl(graybat::communicationPolicy::Context<T_CommunicationPolicy> const context,
+                                                          T_Recv& recvData)
+            -> graybat::communicationPolicy::Event<T_CommunicationPolicy> {
+
+                using CommunicationPolicy = T_CommunicationPolicy;
+                using Event   = graybat::communicationPolicy::Event<CommunicationPolicy>;
+                using Message = graybat::communicationPolicy::socket::Message<CommunicationPolicy>;                
+                
+		hana::tuple<MsgType, ContextID, VAddr, Tag> keys;
+		VAddr destVAddr;
+		Tag tag;
+
+		Message message(std::move(inBox.waitDequeue(keys, MsgType::PEER, context.getID())));
+		destVAddr = hana::at(keys, hana::size_c<2>);
+		tag = hana::at(keys, hana::size_c<3>);
+
+                memcpy (static_cast<void*>(recvData.data()),
+			static_cast<std::int8_t*>(message.getData()),
+			sizeof(typename T_Recv::value_type) * recvData.size());
+
+		return Event(getMsgID(), context, destVAddr, tag, *(static_cast<CommunicationPolicy*>(this)));
+		
+            }
+
+            template <typename T_CommunicationPolicy>
+	    auto Base<T_CommunicationPolicy>::getMsgID()
+                -> graybat::communicationPolicy::MsgID<T_CommunicationPolicy> {
+		return maxMsgID++;
+	    }
+
+
+            template <typename T_CommunicationPolicy>
+            auto Base<T_CommunicationPolicy>::handleRecv()
+                -> void {
+
+                using CommunicationPolicy = T_CommunicationPolicy;                
+                using Message = graybat::communicationPolicy::socket::Message<CommunicationPolicy>;
+               
+                while(true){
+                    
+                    Message message;
+                    static_cast<CommunicationPolicy*>(this)->recvFromSocket(static_cast<CommunicationPolicy*>(this)->recvSocket, message);
+                    
+                    //std::cout << "recv handler: " << static_cast<int>(message.getMsgType()) << " " << message.getMsgID() << " " << message.getContextID() << " " << message.getVAddr() << " " << message.getTag() << std::endl;
+			
+                    if(message.getMsgType() == MsgType::DESTRUCT){
+                        return;
+                    }
+
+                    if(message.getMsgType() == MsgType::PEER){
+                        std::array<unsigned,0>  null;
+                        Context context = contexts.at(message.getContextID());
+                        static_cast<CommunicationPolicy*>(this)->asyncSendImpl(MsgType::CONFIRM, message.getMsgID(), context, message.getVAddr(), message.getTag(), null);
+                    }
+			
+                    inBox.enqueue(std::move(message), message.getMsgType(), message.getContextID(), message.getVAddr(), message.getTag());
+
+                }
+
+            }
+
+        } // socket
+        
+    } // communicationPolicy
+    
+} // graybat

--- a/include/graybat/communicationPolicy/socket/Traits.hpp
+++ b/include/graybat/communicationPolicy/socket/Traits.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+namespace graybat {
+    
+    namespace communicationPolicy {
+
+        namespace socket {
+        
+            namespace traits {
+
+                template <typename T_CommunicationPolicy>
+                struct UriType;
+
+                template <typename T_CommunicationPolicy>
+                struct SocketType;
+
+                template <typename T_CommunicationPolicy>
+                struct MessageType;
+            
+            
+            } // namespace traits
+
+            template <typename T_CommunicationPolicy>
+            using Uri = typename traits::UriType<T_CommunicationPolicy>::type;        
+
+            template <typename T_CommunicationPolicy>
+            using Socket = typename traits::SocketType<T_CommunicationPolicy>::type;        
+        
+            template <typename T_CommunicationPolicy>
+            using Message = typename traits::MessageType<T_CommunicationPolicy>::type;
+            
+        } // namespace socket
+            
+    } // namespace communicationPolicy
+    
+} // namespace graybat

--- a/include/graybat/communicationPolicy/zmq/Message.hpp
+++ b/include/graybat/communicationPolicy/zmq/Message.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <graybat/communicationPolicy/Traits.hpp>
+
+namespace graybat {
+    
+    namespace communicationPolicy {
+    
+        namespace zmq {
+
+            template <typename T_CommunicationPolicy>
+            struct Message {
+
+                // Types
+                using CommunicationPolicy = T_CommunicationPolicy;
+                using ContextID           = typename graybat::communicationPolicy::ContextID<CommunicationPolicy>;
+                using VAddr               = typename graybat::communicationPolicy::VAddr<CommunicationPolicy>;
+                using Tag                 = typename graybat::communicationPolicy::Tag<CommunicationPolicy>;                
+                using MsgType             = typename graybat::communicationPolicy::MsgType<CommunicationPolicy>;
+                using MsgID               = typename graybat::communicationPolicy::MsgID<CommunicationPolicy>;
+
+                // Members
+                ::zmq::message_t message;
+
+                // Methods
+                Message(){
+
+                }
+                
+                template <typename T_Data>
+                Message(MsgType const msgType,  
+                        MsgID const msgID,
+                        ContextID const contextID,
+                        VAddr const srcVAddr,
+                        Tag const tag,      
+                        T_Data & data) : message(sizeof(MsgType) +
+                                                       sizeof(MsgID) +
+                                                       sizeof(ContextID) +
+                                                       sizeof(VAddr) +
+                                                       sizeof(Tag) +
+                                                       data.size() * sizeof(typename T_Data::value_type)){
+
+                    size_t    msgOffset(0);
+                    memcpy (static_cast<char*>(message.data()) + msgOffset, &msgType,    sizeof(MsgType));   msgOffset += sizeof(MsgType);
+                    memcpy (static_cast<char*>(message.data()) + msgOffset, &msgID,      sizeof(MsgID));     msgOffset += sizeof(MsgID);		
+                    memcpy (static_cast<char*>(message.data()) + msgOffset, &contextID,  sizeof(ContextID)); msgOffset += sizeof(ContextID);
+                    memcpy (static_cast<char*>(message.data()) + msgOffset, &srcVAddr,   sizeof(VAddr));     msgOffset += sizeof(VAddr);
+                    memcpy (static_cast<char*>(message.data()) + msgOffset, &tag,        sizeof(Tag));       msgOffset += sizeof(Tag);
+                    memcpy (static_cast<char*>(message.data()) + msgOffset, data.data(), sizeof(typename T_Data::value_type) * data.size());
+
+                }
+
+                MsgType getMsgType(){
+                    MsgType msgType;
+                    memcpy (&msgType, static_cast<char*>(message.data()), sizeof(MsgType));
+                    return msgType;
+
+                    
+                }
+
+                MsgID getMsgID(){
+                    MsgID   msgID;
+                    memcpy (&msgID, static_cast<char*>(message.data()) + sizeof(MsgType), sizeof(MsgID));
+                    return msgID;
+                    
+                }
+
+                ContextID getContextID(){
+                    ContextID contextID;
+                    memcpy (&contextID, static_cast<char*>(message.data()) + sizeof(MsgType) + sizeof(MsgID), sizeof(ContextID));
+                    return contextID;
+                    
+                }
+
+                VAddr getVAddr(){
+                    VAddr vAddr;
+                    memcpy (&vAddr, static_cast<char*>(message.data()) + sizeof(MsgType) + sizeof(MsgID) + sizeof(ContextID), sizeof(VAddr));
+                    return vAddr;
+
+                }
+
+                Tag getTag(){
+                    Tag tag;
+                    memcpy (&tag, static_cast<char*>(message.data()) + sizeof(MsgType) + sizeof(MsgID) + sizeof(ContextID) + sizeof(VAddr), sizeof(Tag));
+                    return tag;
+
+                }
+
+                std::int8_t* getData(){
+                    return static_cast<std::int8_t*>(message.data()) + sizeof(MsgType) + sizeof(MsgID) + sizeof(ContextID) + sizeof(VAddr) + sizeof(Tag);
+                    
+                }
+                
+                ::zmq::message_t& getMessage(){
+                    return message;
+                }
+                
+            };
+
+            
+        } // zmq
+        
+    } // namespace communicationPolicy
+	
+} // namespace graybat

--- a/test/CommunicationPolicyUT.cpp
+++ b/test/CommunicationPolicyUT.cpp
@@ -84,6 +84,14 @@ BOOST_AUTO_TEST_SUITE( graybat_cp_point_to_point )
 /***************************************************************************
  * Test Cases
  ****************************************************************************/
+BOOST_AUTO_TEST_CASE( construct ){
+    hana::for_each(communicationPolicies, [](auto cpRef){
+            (void) cpRef;
+        });
+
+}
+
+
 BOOST_AUTO_TEST_CASE( context ){
     hana::for_each(communicationPolicies, [](auto cpRef){
 	    // Test setup
@@ -96,8 +104,9 @@ BOOST_AUTO_TEST_CASE( context ){
 	    {	
 		Context oldContext = cp.getGlobalContext();
 		for(unsigned i = 0; i < nRuns; ++i){
-		    Context newContext = cp.splitContext( true, oldContext);
-		    oldContext = newContext;
+                    //std::cout << "Run: " << i << std::endl;
+                    Context newContext = cp.splitContext( true, oldContext);
+                    oldContext = newContext;
 		    progress.print( nRuns, i);
 	
 		}


### PR DESCRIPTION
This PR separates the ZeroMQ communication policy in socket base class and a ZeroMQ class. The socket base class provides the signalling management, high level communication and message buffering. The ZeroMQ class now only provides socket management and low level communication methods.

Based on this PR, further socket based communication policies can be implemented (websockets, [boost.Asio](https://github.com/ComputationalRadiationPhysics/graybat/milestones/Boost::Asio%20Communication%20Policy) etc.)

This PR fixes #83.
