### PR TITLE
ContextID generalized

### DIFF
--- a/include/graybat/communicationPolicy/BMPI.hpp
+++ b/include/graybat/communicationPolicy/BMPI.hpp
@@ -53,7 +53,12 @@ namespace graybat {
                 using type = graybat::communicationPolicy::bmpi::Context<BMPI>;
             };
 
-            template<>
+			template<>
+			struct ContextIDType<BMPI> {
+				using type = unsigned;
+			};
+
+			template<>
             struct EventType<BMPI> {
                 using type = graybat::communicationPolicy::bmpi::Event;
             };

--- a/include/graybat/communicationPolicy/Traits.hpp
+++ b/include/graybat/communicationPolicy/Traits.hpp
@@ -10,6 +10,9 @@ namespace graybat {
             struct ContextType;
 
             template <typename T_CommunicationPolicy>
+            struct ContextIDType;
+
+            template <typename T_CommunicationPolicy>
             struct EventType;
 
             template <typename T_CommunicationPolicy>
@@ -23,9 +26,7 @@ namespace graybat {
         template <typename T_CommunicationPolicy>
         using Tag = unsigned;
 
-        template <typename T_CommunicationPolicy>        
-        using ContextID = unsigned;
-        
+
         enum class MsgTypeType : std::int8_t { VADDR_REQUEST = 0,
                 VADDR_LOOKUP = 1,
                 DESTRUCT = 2,
@@ -45,6 +46,10 @@ namespace graybat {
 
         template <typename T_CommunicationPolicy>
         using Context = typename traits::ContextType<T_CommunicationPolicy>::type;
+
+        template <typename T_CommunicationPolicy>
+        using ContextID = typename traits::ContextIDType<T_CommunicationPolicy>::type;
+
 
         template <typename T_CommunicationPolicy>
         using Event = typename traits::EventType<T_CommunicationPolicy>::type;

--- a/include/graybat/communicationPolicy/ZMQ.hpp
+++ b/include/graybat/communicationPolicy/ZMQ.hpp
@@ -46,6 +46,11 @@ namespace graybat {
             };
 
             template<>
+            struct ContextIDType<ZMQ> {
+                using type = unsigned;
+            };
+
+            template<>
             struct EventType<ZMQ> {
                 using type = graybat::communicationPolicy::zmq::Event<ZMQ>;
             };
@@ -143,12 +148,13 @@ namespace graybat {
 	     *
 	     ***************************************************************************/
 
-            void createSocketsToPeers(){
-                for(auto const &vAddr : initialContext){                
-		    sendSockets.emplace_back(Socket(zmqContext, ZMQ_PUSH));
-		    ctrlSendSockets.emplace_back(Socket(zmqContext, ZMQ_PUSH));                    
-                }
+        void createSocketsToPeers(){
+            for(auto const &vAddr : initialContext){
+                (void)vAddr;
+                sendSockets.emplace_back(Socket(zmqContext, ZMQ_PUSH));
+                ctrlSendSockets.emplace_back(Socket(zmqContext, ZMQ_PUSH));
             }
+        }
             
             template <typename T_Socket>
             void connectToSocket(T_Socket& socket, std::string const signalingUri) {

--- a/include/graybat/communicationPolicy/socket/Traits.hpp
+++ b/include/graybat/communicationPolicy/socket/Traits.hpp
@@ -28,6 +28,9 @@ namespace graybat {
         
             template <typename T_CommunicationPolicy>
             using Message = typename traits::MessageType<T_CommunicationPolicy>::type;
+
+            template <typename T_CommunicationPolicy>
+            using ContextName = std::string;
             
         } // namespace socket
             

--- a/include/graybat/communicationPolicy/zmq/Config.hpp
+++ b/include/graybat/communicationPolicy/zmq/Config.hpp
@@ -11,6 +11,7 @@ namespace graybat {
                 std::string masterUri;
                 std::string peerUri;
                 size_t contextSize;
+                std::string contextName = "context";
                 size_t maxBufferSize = 100 * 1000 * 1000;
             };
 

--- a/include/graybat/communicationPolicy/zmq/Context.hpp
+++ b/include/graybat/communicationPolicy/zmq/Context.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+// STL
+#include <numeric>
+
+// GRAYBAT
 #include <graybat/communicationPolicy/Traits.hpp>
 #include <graybat/communicationPolicy/zmq/VAddrIterator.hpp>
 
@@ -28,7 +32,8 @@ namespace graybat {
                     contextID(0),
                     vAddr(0),
                     nPeers(1),
-                    isValid(false){
+                    isValid(false),
+                    peers(0){
 
                 }
 
@@ -36,8 +41,20 @@ namespace graybat {
                     contextID(contextID),
                     vAddr(vAddr),
                     nPeers(nPeers),
-                    isValid(true){
-		
+                    isValid(true),
+                    peers(0){
+
+
+                    peers.resize(nPeers);
+                    std::iota(peers.begin(), peers.end(), 0);
+                }
+
+                Context(ContextID contextID, VAddr vAddr, std::vector<VAddr> peers) :
+                    contextID(contextID),
+                    vAddr(vAddr),
+                    nPeers(peers.size()),
+                    isValid(true),
+                    peers(peers) {
                 }
 
                 size_t size() const{
@@ -56,27 +73,28 @@ namespace graybat {
                     return isValid;
                 }
 
-                VAddrIterator<T_CP> begin(){
-                    return VAddrIterator<T_CP>(0);
+                std::vector<VAddr>::iterator begin(){
+                    return peers.begin();
                 }
 
-                VAddrIterator<T_CP> begin() const {
-                    return VAddrIterator<T_CP>(0);
-                }
-                
-                VAddrIterator<T_CP> end(){
-                    return VAddrIterator<T_CP>(size());
+                std::vector<VAddr>::const_iterator begin() const {
+                    return peers.cbegin();
                 }
 
-                VAddrIterator<T_CP> end() const {
-                    return VAddrIterator<T_CP>(size());
+                std::vector<VAddr>::iterator end(){
+                    return peers.end();
+                }
+
+                std::vector<VAddr>::const_iterator end() const {
+                    return peers.cend();
                 }
                 
             private:	
                 ContextID contextID;
                 VAddr     vAddr;
                 unsigned  nPeers;
-                bool      isValid;		
+                bool      isValid;
+                std::vector<VAddr> peers;
             };
 
 

--- a/test/CageUT.cpp
+++ b/test/CageUT.cpp
@@ -84,7 +84,8 @@ using BMPIConfig = BMPI::Config;
 
 ZMQConfig zmqConfig = {"tcp://127.0.0.1:5000",
                        "tcp://127.0.0.1:5001",
-                       static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE")))};
+                       static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
+					   "context_cage_test"};
 
 BMPIConfig bmpiConfig;
 

--- a/test/CommunicationPolicyUT.cpp
+++ b/test/CommunicationPolicyUT.cpp
@@ -28,7 +28,8 @@ using BMPIConfig = BMPI::Config;
 
 ZMQConfig zmqConfig = {"tcp://127.0.0.1:5000",
                        "tcp://127.0.0.1:5001",
-                       static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE")))};
+                       static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
+                       "context_cp_test"};
 
 BMPIConfig bmpiConfig;
 

--- a/test/EdgeUT.cpp
+++ b/test/EdgeUT.cpp
@@ -35,7 +35,8 @@ using BMPIConfig = BMPI::Config;
 
 ZMQConfig zmqConfig = {"tcp://127.0.0.1:5000",
                        "tcp://127.0.0.1:5001",
-                       static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE")))};
+                       static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
+					   "context_edge_test"};
 
 BMPIConfig bmpiConfig;
 

--- a/test/VertexUT.cpp
+++ b/test/VertexUT.cpp
@@ -36,7 +36,8 @@ using BMPIConfig = BMPI::Config;
 
 ZMQConfig zmqConfig = {"tcp://127.0.0.1:5000",
                        "tcp://127.0.0.1:5001",
-                       static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE")))};
+                       static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
+					   "context_vertex_test"};
 
 BMPIConfig bmpiConfig;
 

--- a/utils/zmq_signaling_server.cpp
+++ b/utils/zmq_signaling_server.cpp
@@ -16,8 +16,9 @@
 #include <zmq.hpp>
 
 // Type defs
-typedef unsigned Tag;                                            
+typedef unsigned Tag;
 typedef unsigned ContextID;
+typedef std::string ContextName;
 typedef unsigned VAddr;
 typedef unsigned MsgType;
 typedef std::string Uri;
@@ -38,9 +39,9 @@ static char * s_recv (zmq::socket_t& socket) {
     zmq::message_t message(256);
     socket.recv(&message);
     if (message.size() == static_cast<size_t>(-1))
-	return NULL;
+        return NULL;
     if (message.size() > 255)
-	static_cast<char*>(message.data())[255] = 0;
+        static_cast<char*>(message.data())[255] = 0;
     return strdup (static_cast<char*>(message.data()));
 }
 
@@ -58,64 +59,66 @@ int main(const int argc, char **argv){
      **************************************************************************/
     namespace po = boost::program_options;
     po::options_description options( "ZMQ Signaling Server Options" );
-    
+
     options.add_options()
-        ("port,p",
-         po::value<unsigned>()->default_value(5000),
-         "Port to listen for signaling requests")
-        ("ip",
-         po::value<std::string>(),
-         "IP to listen for signaling requests. Either ip or interface can be specified. (Example: 127.0.0.1)")
-		("interface,i",
-         po::value<std::string>(),
-         "Interface to listen for signaling requests. Either ip or interface can be specified. Default are all available interfaces. (Example: eth0)")
-		("protocoll",
-         po::value<std::string>()->default_value("tcp"),
-         "Protocoll to listen for signaling requests. Options are tcp and udp. Default is udp.")
-        ("help,h",
-         "Print this help message and exit");
+            ("port,p",
+             po::value<unsigned>()->default_value(5000),
+             "Port to listen for signaling requests")
+            ("ip",
+             po::value<std::string>(),
+             "IP to listen for signaling requests. Either ip or interface can be specified. (Example: 127.0.0.1)")
+            ("interface,i",
+             po::value<std::string>(),
+             "Interface to listen for signaling requests. Either ip or interface can be specified. Default are all available interfaces. (Example: eth0)")
+            ("protocoll",
+             po::value<std::string>()->default_value("tcp"),
+             "Protocoll to listen for signaling requests. Options are tcp and udp. Default is udp.")
+            ("help,h",
+             "Print this help message and exit");
 
 
     po::variables_map vm;
     po::store(po::parse_command_line( argc, argv, options ), vm);
-    
+
     if(vm.count("help")){
         std::cout << "Usage: " << argv[0] << " [options] " << std::endl;
         std::cout << options << std::endl;
         exit(0);
     }
-    
+
     if(vm.count("ip") && vm.count("interface")) {
-		std::cerr << "Error: Only one of the following can be specified by parameter. Either ip or interface." << std::endl;
-		exit(1);
-	}
-	
-	std::string masterUri;
-	if(vm.count("ip")) {
-		//Listen to ip
-		masterUri = vm["protocoll"].as<std::string>() + "://" + vm["ip"].as<std::string>() + ":" + std::to_string(vm["port"].as<unsigned>());
-	} else  if(vm.count("interface")) {
-		//Listen to interface
-		masterUri = vm["protocoll"].as<std::string>() + "://" + vm["interface"].as<std::string>() + ":" + std::to_string(vm["port"].as<unsigned>());	
-	} else {
-		//Listen to all interfaces
-		masterUri = vm["protocoll"].as<std::string>() + "://*:" + std::to_string(vm["port"].as<unsigned>());
-	}
-	
+        std::cerr << "Error: Only one of the following can be specified by parameter. Either ip or interface." << std::endl;
+        exit(1);
+    }
+
+    std::string masterUri;
+    if(vm.count("ip")) {
+        //Listen to ip
+        masterUri = vm["protocoll"].as<std::string>() + "://" + vm["ip"].as<std::string>() + ":" + std::to_string(vm["port"].as<unsigned>());
+    } else  if(vm.count("interface")) {
+        //Listen to interface
+        masterUri = vm["protocoll"].as<std::string>() + "://" + vm["interface"].as<std::string>() + ":" + std::to_string(vm["port"].as<unsigned>());
+    } else {
+        //Listen to all interfaces
+        masterUri = vm["protocoll"].as<std::string>() + "://*:" + std::to_string(vm["port"].as<unsigned>());
+    }
+
     /***************************************************************************
      * Start signaling
      **************************************************************************/
-    
+
     std::cout << "Start zmq signaling server" << std::endl;
 
     std::map<ContextID, std::map<VAddr, Uri> > phoneBook;
-    std::map<ContextID, std::map<VAddr, Uri> > ctrlPhoneBook;    
+    std::map<ContextID, std::map<VAddr, Uri> > ctrlPhoneBook;
     std::map<ContextID, VAddr> maxVAddr;
+    std::map<ContextID, std::vector<Uri> > peers;
+    std::map<ContextName, ContextID> contextIds;
 
     std::cout << "Listening on: " << masterUri << std::endl;
-    
+
     zmq::context_t context(1);
-    
+
     zmq::message_t request;
     zmq::message_t reply;
     zmq::socket_t socket (context, ZMQ_REP);
@@ -123,99 +126,104 @@ int main(const int argc, char **argv){
     socket.setsockopt( ZMQ_RCVHWM, &hwm, sizeof(hwm));
     socket.setsockopt( ZMQ_SNDHWM, &hwm, sizeof(hwm));
 
-    
+
     socket.bind(masterUri.c_str());
 
     ContextID maxContextID = 0;
-    ContextID maxInitialContextID = maxContextID;    
+    ContextID maxInitialContextID = maxContextID;
 
     while(true){
         std::stringstream ss;
         ss << s_recv(socket);
 
         Uri srcUri;
-        Uri ctrlUri;        
+        Uri ctrlUri;
         MsgType type;
-	ContextID contextID;
-	unsigned size;
+        ContextID contextID;
+        ContextName contextName;
+        unsigned size;
         ss >> type;
 
         switch(type){
 
-	case CONTEXT_INIT:
-	    {
+            case CONTEXT_REQUEST:
+            {
+                ss >> contextName;
+                if(contextIds.find(contextName) != contextIds.end()){
+                    contextID = contextIds.at(contextName);
+                }
+                else {
+                    contextID = maxContextID++;
+                    contextIds[contextName] = contextID;
+                }
 
-		ss >> size;
-		if(maxVAddr[maxInitialContextID]  == size){
-		    maxInitialContextID = ++maxContextID;
-		    maxVAddr[maxInitialContextID] = 0;
-		}
-		s_send(socket, (std::to_string(maxInitialContextID) + " ").c_str());
-		std::cout << "CONTEXT INIT [size:" << size << "]: " << maxInitialContextID << std::endl;		
-		break;
-	    }
+                s_send(socket, (std::to_string(contextID) + " ").c_str());
+                std::cout << "CONTEXT REQUEST [name:" << contextName << "]: " << contextID << std::endl;
+                break;
 
-	case CONTEXT_REQUEST:
-	    {
-		ss >> size;
-		maxVAddr[++maxContextID] = 0;
-		s_send(socket, (std::to_string(maxContextID) + " ").c_str());
-		std::cout << "CONTEXT REQUEST [size:" << size << "]: " << maxContextID << std::endl;				
-		break;
+            }
 
-	    }
-	    
-        case VADDR_REQUEST:
+            case VADDR_REQUEST:
             {
                 // Reply with correct information
-		ss >> contextID;
+                ss >> contextID;
                 ss >> srcUri;
                 ss >> ctrlUri;
 
-                phoneBook[contextID][maxVAddr[contextID]] = srcUri;
-                ctrlPhoneBook[contextID][maxVAddr[contextID]] = ctrlUri;                
-                s_send(socket, (std::to_string(maxVAddr[contextID]) + " ").c_str());
-		std::cout << "VADDR REQUEST [contextID:" << contextID << "][srcUri:" << srcUri << "]" << "[ctrlUri:" << ctrlUri << "]:" <<  maxVAddr[contextID] << std::endl;
-		maxVAddr[contextID]++;		
+                peers[contextID].push_back(srcUri);
+                VAddr vAddr = peers[contextID].size() - 1;
+
+                phoneBook[contextID][vAddr] = srcUri;
+                ctrlPhoneBook[contextID][vAddr] = ctrlUri;
+                s_send(socket, (std::to_string(vAddr) + " ").c_str());
+                std::cout << "VADDR REQUEST [contextID:" << contextID << "][srcUri:" << srcUri << "]" << "[ctrlUri:" << ctrlUri << "]:" <<  vAddr << std::endl;
                 break;
             }
-                        
-        case VADDR_LOOKUP:
+
+            case VADDR_LOOKUP:
             {
                 VAddr remoteVAddr;
-		ss >> contextID;
-                ss >> remoteVAddr;		
-		
+                ss >> contextID;
+                ss >> remoteVAddr;
+
                 std::stringstream sss;
 
                 if(phoneBook[contextID].count(remoteVAddr) == 0){
                     sss << RETRY << " ";
                     s_send(socket, sss.str().c_str());
-		    std::cout << "VADDR LOOKUP [contextID:" << contextID << "][remoteVAddr:" << remoteVAddr << "]: " << " RETRY " << std::endl;		    		    
+                    //std::cout << "VADDR LOOKUP [contextID:" << contextID << "][remoteVAddr:" << remoteVAddr << "]: " << " RETRY " << std::endl;
                 }
                 else {
                     sss << ACK << " " << phoneBook[contextID][remoteVAddr] << " " << ctrlPhoneBook[contextID][remoteVAddr] << " ";
                     s_send(socket, sss.str().c_str());
-		    std::cout << "VADDR LOOKUP [contextID:" << contextID << "][remoteVAddr:" << remoteVAddr << "]: " << phoneBook[contextID][remoteVAddr] << " " << ctrlPhoneBook[contextID][remoteVAddr] << std::endl;
+                    //std::cout << "VADDR LOOKUP [contextID:" << contextID << "][remoteVAddr:" << remoteVAddr << "]: " << phoneBook[contextID][remoteVAddr] << " " << ctrlPhoneBook[contextID][remoteVAddr] << std::endl;
                 }
 
                 break;
             }
 
-        case DESTRUCT:
-            s_send(socket, " ");
-	    std::cout << "DESTRUCT" << std::endl;
-            break;
-                        
-        default:
-            // Reply empty message
-            s_send(socket, " ");
-	    std::cout << "UNKNOWN MESSAGE TYPE" << std::endl;
-	    exit(0);
-            break;
+            case DESTRUCT:
+                ss >> contextName;
+                if(contextIds.find(contextName) != contextIds.end()){
+                    contextIds.erase(contextIds.find(contextName));
+                }
+//                else {
+//                    contextID = maxContextID++;
+//                    contextIds[contextName] = contextID;
+//                }
+
+                s_send(socket, " ");
+                std::cout << "DESTRUCT" << std::endl;
+                break;
+            default:
+                // Reply empty message
+                s_send(socket, " ");
+                std::cout << "UNKNOWN MESSAGE TYPE" << std::endl;
+                exit(0);
+                break;
 
         };
-                    
+
     }
 
 }


### PR DESCRIPTION
Contexts can now be referenced by abitrary IDs such as strings. Strings are easier to handle especially when connecting to an already existing context. This feature will be used to connect to a context even if this context was already initialised.
