### PR TITLE
Made cage move constructable

### DIFF
--- a/include/graybat/communicationPolicy/BMPI.hpp
+++ b/include/graybat/communicationPolicy/BMPI.hpp
@@ -103,21 +103,27 @@ namespace graybat {
             using Uri       = int;
 
 	    BMPI(Config const) :contextCount(0),
-		    uriMap(0),
-		    initialContext(contextCount, mpi::communicator()){
+							uriMap(0),
+							initialContext(contextCount, mpi::communicator()){
 
-		uriMap.push_back(std::vector<Uri>());
+			uriMap.push_back(std::vector<Uri>());
 		
-                for(auto const &vAddr : initialContext){                    
-		    uriMap.back().push_back(vAddr);
-		}
+			for(auto const &vAddr : initialContext){
+				uriMap.back().push_back(vAddr);
+			}
 
 	    }
 
-	    // Destructor
-	    ~BMPI(){
-		
-	    }
+		// Copy constructor
+		BMPI(BMPI&) = delete;
+		// Copy assignment constructor
+		BMPI& operator=(BMPI&) = delete;
+		// Move constructor
+		BMPI(BMPI&&) = delete;
+		// Move assignment constructor
+		BMPI& operator=(BMPI&&) = delete;
+        // Destructor
+	    ~BMPI(){}
 	    /***********************************************************************//**
              *
 	     * @name Point to Point Communication Interface

--- a/include/graybat/communicationPolicy/ZMQ.hpp
+++ b/include/graybat/communicationPolicy/ZMQ.hpp
@@ -151,14 +151,19 @@ namespace graybat {
                 
             }
 
-	    // Destructor
-	    ~ZMQ(){
-                SocketBase::deinit();
-	    }
-            
+        // Copy constructor
+        ZMQ(ZMQ &)  = delete;
+        // Copy assignment constructor
+        ZMQ& operator=(ZMQ &) = delete;
+        // Move constructor
 	    ZMQ(ZMQ &&other) = delete;
-	    ZMQ(ZMQ &other)  = delete;
+        // Move assignment constructor
+        ZMQ& operator=(ZMQ &&) = delete;
 
+        // Destructor
+        ~ZMQ(){
+            SocketBase::deinit();
+        }
 
 	    /***********************************************************************//**
              *

--- a/include/graybat/communicationPolicy/socket/Base.hpp
+++ b/include/graybat/communicationPolicy/socket/Base.hpp
@@ -89,9 +89,17 @@ namespace graybat {
                 std::thread recvHandler;
                 std::thread ctrlHandler;
 
-                // Construct/Destruct Methods
+                // Constructor
                 Base(Config const config);
-
+                // Copy constructor
+                Base(Base&) = delete;
+                // Copy assignment constructor
+                Base& operator=(Base&) = delete;
+                // Move constructor
+                Base(Base&&) = delete;
+                // Move assigment constructor
+                Base& operator=(Base&&) = delete;
+                // Destructor
                 ~Base();
 
                 void init();

--- a/test/CageUT.cpp
+++ b/test/CageUT.cpp
@@ -81,43 +81,67 @@ struct Progress {
 
 };
 
+
+
+
 /*******************************************************************************
  * Test Suites
  ******************************************************************************/
+
+
+/***************************************************************************
+ * Test Cases
+ ****************************************************************************/
 BOOST_AUTO_TEST_SUITE( graybat_cage_point_to_point_test )
 
 
 /*******************************************************************************
  * Communication Policies to Test
  ******************************************************************************/
-namespace hana = boost::hana;
+    namespace hana = boost::hana;
 
-size_t const nRuns = 1000;
+    size_t const nRuns = 1000;
 
-using ZMQ        = graybat::communicationPolicy::ZMQ;
-using BMPI       = graybat::communicationPolicy::BMPI;
-using GP         = graybat::graphPolicy::BGL<>;
-using ZMQCage    = graybat::Cage<ZMQ, GP>;
-using BMPICage   = graybat::Cage<BMPI, GP>;
-using ZMQConfig  = ZMQ::Config;
-using BMPIConfig = BMPI::Config;
+    using ZMQ        = graybat::communicationPolicy::ZMQ;
+    using BMPI       = graybat::communicationPolicy::BMPI;
+    using GP         = graybat::graphPolicy::BGL<>;
+    using ZMQCage    = graybat::Cage<ZMQ, GP>;
+    using BMPICage   = graybat::Cage<BMPI, GP>;
+    using ZMQConfig  = ZMQ::Config;
+    using BMPIConfig = BMPI::Config;
 
-ZMQConfig zmqConfig = {"tcp://127.0.0.1:5000",
-                       "tcp://127.0.0.1:5001",
-                       static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
-					   "context_cage_test"};
+    ZMQConfig zmqConfig = {"tcp://127.0.0.1:5000",
+                           "tcp://127.0.0.1:5001",
+                           static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
+                           "context_cage_test"};
 
-BMPIConfig bmpiConfig;
+    BMPIConfig bmpiConfig;
 
-ZMQCage zmqCage(zmqConfig);
-BMPICage bmpiCage(bmpiConfig);
+    ZMQCage zmqCage(zmqConfig);
+    BMPICage bmpiCage(bmpiConfig);
 
-auto cages = hana::make_tuple(std::ref(zmqCage),
-                              std::ref(bmpiCage) );
+    auto cages = hana::make_tuple(std::ref(zmqCage),
+                                  std::ref(bmpiCage) );
 
-/***************************************************************************
- * Test Cases
- ****************************************************************************/
+//    auto cages = hana::make_tuple(std::ref(zmqCage));
+
+
+
+    BOOST_AUTO_TEST_CASE( move_construct ){
+        hana::for_each(cages, [](auto cageRef) {
+            // Test setup
+            using Cage    = typename decltype(cageRef)::type;
+
+            // Test run
+            {
+                auto &cage = cageRef.get();
+                auto cage2 = std::move(cage);
+                std::cout << cage2.getPeers().size() << std::endl;
+                cage = std::move(cage2);
+            }
+        });
+    }
+
 BOOST_AUTO_TEST_CASE( send_recv ){
     hana::for_each(cages, [](auto cageRef){
 	    // Test setup


### PR DESCRIPTION
This PR adds support for move construction to the cage. This was implemented using the [pimpl-pattern](https://en.wikipedia.org/wiki/Opaque_pointer). This PR should fix #74.
