### PR TITLE
Added BufferAdaptor and some STL implementations of it

### DIFF
--- a/include/graybat/utils/BufferAdapter.hpp
+++ b/include/graybat/utils/BufferAdapter.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <type_traits>
+#include <vector>
+#include <array>
+#include <cstddef> // size_t
+#include <cstring> // memcpy
+
+namespace utils {
+
+template <class Type>
+//using  linear_memory_check = std::is_pod<Type>;
+//using  linear_memory_check = std::is_trivial<Type>;
+//using  linear_memory_check = std::is_trivially_copyable<Type>;
+//using  linear_memory_check = std::is_standard_layout<Type>;
+using  linear_memory_check = std::is_trivially_destructible<Type>;
+
+
+
+template <class Type, class enable = void>
+struct BufferAdapter; // End of class BufferAdapter
+
+
+template <
+	class Type
+>
+struct BufferAdapter<
+	Type,
+	typename std::enable_if<
+		linear_memory_check<Type>::value
+	>::type
+> {
+	const void* data;
+	const size_t size;
+
+	BufferAdapter(Type& input) :
+		data(&input),
+		size(sizeof(Type))
+	{};
+
+	BufferAdapter(void* data, size_t size) :
+		data(data),
+		size(size)
+	{};
+
+	void copyTo(Type& destination) {
+		memcpy(
+			&destination,
+			data,
+			size
+		);
+	}
+}; // End of struct BufferAdapter
+
+template <class Type>
+BufferAdapter<Type> make_buffer_adaptor(Type& input) {
+	return BufferAdapter<Type>(input);
+}
+
+} // End of namespace utils

--- a/include/graybat/utils/StlAdapter/Deque.hpp
+++ b/include/graybat/utils/StlAdapter/Deque.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "../BufferAdapter.hpp"
+#include <deque>
+
+namespace utils {
+
+template <
+	class Type
+>
+struct BufferAdapter<
+	std::deque<Type>,
+	typename std::enable_if<
+		std::is_trivially_copyable<Type>::value
+	>::type
+> {
+	const void* data;
+	const size_t size;
+
+	BufferAdapter(std::deque<Type>& input) :
+		data(&input[0]),
+		size(input.size()*sizeof(Type))
+	{};
+
+	BufferAdapter(void* data, size_t size) :
+		data(data),
+		size(size)
+	{};
+
+	void copyTo(std::deque<Type>& destination) {
+		destination.resize(size / sizeof(Type));
+		memcpy(
+			&destination[0],
+			data,
+			size
+		);
+	}
+
+}; // End of struct BufferAdapter
+
+} // End of namespace utils
+

--- a/include/graybat/utils/StlAdapter/String.hpp
+++ b/include/graybat/utils/StlAdapter/String.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "../BufferAdapter.hpp"
+#include <string>
+
+namespace utils {
+
+template <>
+struct BufferAdapter<
+	std::string
+> {
+
+	const void* data;
+	const size_t size;
+
+	BufferAdapter(std::string& input) :
+		data(input.data()),
+		size(input.size()*sizeof(char))
+	{};
+
+	BufferAdapter(void* data, size_t size) :
+		data(data),
+		size(size)
+	{};
+
+	void copyTo(std::string& destination) {
+		destination.resize(size / sizeof(char));
+		memcpy(
+			&destination[0],
+			data,
+			size
+		);
+	}
+
+}; // End of struct BufferAdapter
+
+} // End of namespace utils
+

--- a/include/graybat/utils/StlAdapter/Vector.hpp
+++ b/include/graybat/utils/StlAdapter/Vector.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "../BufferAdapter.hpp"
+#include <vector>
+
+namespace utils {
+
+template <
+	class Type
+>
+struct BufferAdapter<
+	std::vector<Type>,
+	typename std::enable_if<
+		std::is_trivially_copyable<Type>::value
+	>::type
+> {
+
+	const void* data;
+	const size_t size;
+
+	BufferAdapter(std::vector<Type>& input) :
+		data(input.data()),
+		size(input.size()*sizeof(Type))
+	{};
+
+	BufferAdapter(void* data, size_t size) :
+		data(data),
+		size(size)
+	{};
+
+	void copyTo(std::vector<Type>& destination) {
+		destination.resize(size / sizeof(Type));
+		memcpy(
+			destination.data(),
+			data,
+			size
+		);
+	}
+
+}; // End of struct BufferAdapter
+
+} // End of namespace utils


### PR DESCRIPTION
This is not the final solution, but i dont know, where to start to hook things up in graybat.
Where i am at is, that i can convert a Type to a void* and size and back. I know, that you are using memcpy in the background, to copy the messages to the send buffers and from the receive buffer. Since there are specilised implementations for non trivial copyable types, these specialisations take care of resizing the input types if needed.

Now all I need to know, is all places in the communication policies, where this is done to make a clean transition. Maybe we can tackle this on the cage layer but i am not sure about this.