### PR TITLE
Changed c++14 flag to c++11 in graybatConfig.cmake to enable Alpaka with CUDA combability

### DIFF
--- a/graybatConfig.cmake
+++ b/graybatConfig.cmake
@@ -35,7 +35,7 @@ set(graybat_INCLUDE_DIRS ${graybat_INCLUDE_DIRS} "${graybat_DIR}/include")
 ###############################################################################
 # COMPILER FLAGS
 ###############################################################################
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 
 ###############################################################################


### PR DESCRIPTION
This PR is here due to a offline discussion with @theZiz.

The C++14 Flag in Graybat is still prohibiting it from working it
with Alpaka/CUDA. The main problem is that if CUDA(even in version 8.0) is used, C++11 should be used and this is fine for both Alpaka and
Graybat (since @fabian-jung removed the C++14 stuff afaik). The problem
which remains is, that if Graybat sets the ```CMAKE_CXX_FLAG``` to  C++14  Alpaka
will thus not create the Makro ```BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION ``` 
and therefore causes the compilation to fail due to the missing  return type deduction
feature. This would now fix the issue, but since Alpaka as well as Graybat add the C++11
Flag, the user still has to remove the duplicate  manually inside his CMakeslists.txt file (when using CUDA and Alpaka at least since nvcc does not allow duplicate flags). 
The only advantage of this PR is therefore, that the user immediatly sees that the error
is caused by the Flags and can remove them manually instead of having to further
investigate the Alpaka internal cause.

A real solution instead of a workaround imho would be to check if there already exists a
C++11 Flag in both Alpaka and Graybat, and adding it if it does not already exist. Or let the user
take care of it inside his own CMake File.


Also since the tests still require C++14, I could still exchange the C++11 to 14 flag temporarily in the concerned ```CMakeLists.txt```.