### PR TITLE
Add probe to communication policy interface

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,3 @@
----
 BasedOnStyle: WebKit
 Language: Cpp
 NamespaceIndentation: None
@@ -11,4 +10,3 @@ AllowShortFunctionsOnASingleLine: false
 BinPackArguments: false
 BinPackParameters: false
 AlignAfterOpenBracket: AlwaysBreak
----

--- a/include/graybat/communicationPolicy/Traits.hpp
+++ b/include/graybat/communicationPolicy/Traits.hpp
@@ -36,6 +36,9 @@ namespace graybat {
             struct EventType;
 
             template <typename T_CommunicationPolicy>
+            struct StatusType;
+
+            template <typename T_CommunicationPolicy>
             struct ConfigType;
             
         } // namespace traits
@@ -70,9 +73,12 @@ namespace graybat {
         template <typename T_CommunicationPolicy>
         using ContextID = typename traits::ContextIDType<T_CommunicationPolicy>::type;
 
-
         template <typename T_CommunicationPolicy>
         using Event = typename traits::EventType<T_CommunicationPolicy>::type;
+
+        template <typename T_CommunicationPolicy>
+        using Status = typename traits::StatusType<T_CommunicationPolicy>::type;
+
 
         template <typename T_CommunicationPolicy>
         using Config = typename traits::ConfigType<T_CommunicationPolicy>::type;

--- a/include/graybat/communicationPolicy/ZMQ.hpp
+++ b/include/graybat/communicationPolicy/ZMQ.hpp
@@ -21,222 +21,197 @@
 #pragma once
 
 // CLIB
-#include <assert.h>   /* assert */
-#include <string.h>   /* strup */
+#include <assert.h> /* assert */
+#include <string.h> /* strup */
 
 // STL
-#include <assert.h>   /* assert */
-#include <array>      /* array */
-#include <iostream>   /* std::cout */
-#include <map>        /* std::map */
-#include <exception>  /* std::out_of_range */
-#include <sstream>    /* std::stringstream, std::istringstream */
-#include <string>     /* std::string */
+#include <array>     /* array */
+#include <assert.h>  /* assert */
+#include <exception> /* std::out_of_range */
+#include <iostream>  /* std::cout */
+#include <map>       /* std::map */
+#include <sstream>   /* std::stringstream, std::istringstream */
+#include <string>    /* std::string */
 
 // ZMQ
-#include <zmq.hpp>    /* zmq::socket_t, zmq::context_t */
+#include <zmq.hpp> /* zmq::socket_t, zmq::context_t */
 
 // GrayBat
-#include <graybat/communicationPolicy/socket/Base.hpp> /* Base */
 #include <graybat/communicationPolicy/Traits.hpp>
-#include <graybat/communicationPolicy/zmq/Message.hpp> /* Message */
+#include <graybat/communicationPolicy/socket/Base.hpp> /* Base */
+#include <graybat/communicationPolicy/zmq/Config.hpp>  /* Config */
 #include <graybat/communicationPolicy/zmq/Context.hpp> /* Context */
 #include <graybat/communicationPolicy/zmq/Event.hpp>   /* Event */
-#include <graybat/communicationPolicy/zmq/Config.hpp>  /* Config */
-
+#include <graybat/communicationPolicy/zmq/Message.hpp> /* Message */
+#include <graybat/communicationPolicy/zmq/Status.hpp>  /* Event */
 
 namespace graybat {
-    
-    namespace communicationPolicy {
+namespace communicationPolicy {
 
-	/************************************************************************//**
-	 * @class ZMQ
-	 *
-	 * @brief Implementation of the Cage communicationPolicy interface
-	 *        based on ZMQ.
-	 *
-	 ***************************************************************************/
-        struct ZMQ;
+/************************************************************************/ /**
+  * @class ZMQ
+  *
+  * @brief Implementation of the Cage communicationPolicy interface
+  *        based on ZMQ.
+  *
+  ***************************************************************************/
+struct ZMQ;
 
-        namespace traits {
+namespace traits {
 
-            template<>
-            struct ContextType<ZMQ> {
-                using type = graybat::communicationPolicy::zmq::Context<ZMQ>;
-            };
+template <> struct ContextType<ZMQ> {
+  using type = graybat::communicationPolicy::zmq::Context<ZMQ>;
+};
 
-            template<>
-            struct ContextIDType<ZMQ> {
-                using type = unsigned;
-            };
+template <> struct ContextIDType<ZMQ> { using type = unsigned; };
 
-            template<>
-            struct EventType<ZMQ> {
-                using type = graybat::communicationPolicy::zmq::Event<ZMQ>;
-            };
+template <> struct EventType<ZMQ> {
+  using type = graybat::communicationPolicy::zmq::Event<ZMQ>;
+};
 
-            template<>
-            struct ConfigType<ZMQ> {
-                using type = graybat::communicationPolicy::zmq::Config;
-            };
+template <> struct StatusType<ZMQ> {
+  using type = graybat::communicationPolicy::zmq::Status<ZMQ>;
+};
 
-            
-        }
+template <> struct ConfigType<ZMQ> {
+  using type = graybat::communicationPolicy::zmq::Config;
 
-        namespace socket {
+};
+}
 
-            namespace traits {
+namespace socket {
+namespace traits {
 
-                template<>
-                struct UriType<ZMQ> {
-                    using type = std::string;
-                };
+template <> struct UriType<ZMQ> { using type = std::string; };
 
-                template<>
-                struct SocketType<ZMQ> {
-                    using type = ::zmq::socket_t;
-                };
+template <> struct SocketType<ZMQ> { using type = ::zmq::socket_t; };
 
-                template<>
-                struct MessageType<ZMQ> {
-                    using type = graybat::communicationPolicy::zmq::Message<ZMQ>;
-                };
-                
-            }
-            
-        }
+template <> struct MessageType<ZMQ> {
+  using type = graybat::communicationPolicy::zmq::Message<ZMQ>;
+};
 
-	struct ZMQ : public graybat::communicationPolicy::socket::Base<ZMQ> {
-            
-	    // Type defs
-            using Tag        = graybat::communicationPolicy::Tag<ZMQ>;
-            using ContextID  = graybat::communicationPolicy::ContextID<ZMQ>;
-            using MsgID      = graybat::communicationPolicy::MsgID<ZMQ>;
-            using VAddr      = graybat::communicationPolicy::VAddr<ZMQ>;
-            using Context    = graybat::communicationPolicy::Context<ZMQ>;
-            using Event      = graybat::communicationPolicy::Event<ZMQ>;
-            using Config     = graybat::communicationPolicy::Config<ZMQ>;
-            using MsgType    = graybat::communicationPolicy::MsgType<ZMQ>;
-            using Uri        = graybat::communicationPolicy::socket::Uri<ZMQ>;
-            using Socket     = graybat::communicationPolicy::socket::Socket<ZMQ>;            
-            using Message    = graybat::communicationPolicy::socket::Message<ZMQ>;
-            using SocketBase = graybat::communicationPolicy::socket::Base<ZMQ>;
-            
-	    // ZMQ Sockets
-            ::zmq::context_t zmqContext;
-            Socket recvSocket;
-            Socket ctrlSocket;            
-            Socket signalingSocket;
-            std::vector<Socket> sendSockets;
-            std::vector<Socket> ctrlSendSockets;                        
+}
+}
 
-            // Uri
-	    const Uri peerUri;
-            const Uri ctrlUri;
+struct ZMQ : public graybat::communicationPolicy::socket::Base<ZMQ> {
 
+  // Type defs
+  using Tag = graybat::communicationPolicy::Tag<ZMQ>;
+  using ContextID = graybat::communicationPolicy::ContextID<ZMQ>;
+  using MsgID = graybat::communicationPolicy::MsgID<ZMQ>;
+  using VAddr = graybat::communicationPolicy::VAddr<ZMQ>;
+  using Context = graybat::communicationPolicy::Context<ZMQ>;
+  using Event = graybat::communicationPolicy::Event<ZMQ>;
+  using Config = graybat::communicationPolicy::Config<ZMQ>;
+  using MsgType = graybat::communicationPolicy::MsgType<ZMQ>;
+  using Uri = graybat::communicationPolicy::socket::Uri<ZMQ>;
+  using Socket = graybat::communicationPolicy::socket::Socket<ZMQ>;
+  using Message = graybat::communicationPolicy::socket::Message<ZMQ>;
+  using SocketBase = graybat::communicationPolicy::socket::Base<ZMQ>;
 
-            // Construct
-	    ZMQ(Config const config) :
-                SocketBase(config),
-		zmqContext(1),
-                recvSocket(zmqContext, ZMQ_PULL),
-                ctrlSocket(zmqContext, ZMQ_PULL),                
-		signalingSocket(zmqContext, ZMQ_REQ),
-                peerUri(bindToNextFreePort(recvSocket, config.peerUri)),
-                ctrlUri(bindToNextFreePort(ctrlSocket, config.peerUri))                
-            {
+  // ZMQ Sockets
+  ::zmq::context_t zmqContext;
+  Socket recvSocket;
+  Socket ctrlSocket;
+  Socket signalingSocket;
+  std::vector<Socket> sendSockets;
+  std::vector<Socket> ctrlSendSockets;
 
-                //std::cout << "PeerUri: " << peerUri << std::endl;
-                SocketBase::init();
-                
-            }
+  // Uri
+  const Uri peerUri;
+  const Uri ctrlUri;
 
-        // Copy constructor
-        ZMQ(ZMQ &)  = delete;
-        // Copy assignment constructor
-        ZMQ& operator=(ZMQ &) = delete;
-        // Move constructor
-	    ZMQ(ZMQ &&other) = delete;
-        // Move assignment constructor
-        ZMQ& operator=(ZMQ &&) = delete;
+  // Construct
+  ZMQ(Config const config)
+      : SocketBase(config), zmqContext(1), recvSocket(zmqContext, ZMQ_PULL),
+        ctrlSocket(zmqContext, ZMQ_PULL), signalingSocket(zmqContext, ZMQ_REQ),
+        peerUri(bindToNextFreePort(recvSocket, config.peerUri)),
+        ctrlUri(bindToNextFreePort(ctrlSocket, config.peerUri)) {
 
-        // Destructor
-        ~ZMQ(){
-            SocketBase::deinit();
-        }
+    // std::cout << "PeerUri: " << peerUri << std::endl;
+    SocketBase::init();
+  }
 
-	    /***********************************************************************//**
-             *
-	     * @name Socket base utilities
-	     *
-	     * @{
-	     *
-	     ***************************************************************************/
+  // Copy constructor
+  ZMQ(ZMQ &) = delete;
+  // Copy assignment constructor
+  ZMQ &operator=(ZMQ &) = delete;
+  // Move constructor
+  ZMQ(ZMQ &&other) = delete;
+  // Move assignment constructor
+  ZMQ &operator=(ZMQ &&) = delete;
 
-        void createSocketsToPeers(){
-            for(auto const &vAddr : initialContext){
-                (void)vAddr;
-                sendSockets.emplace_back(Socket(zmqContext, ZMQ_PUSH));
-                ctrlSendSockets.emplace_back(Socket(zmqContext, ZMQ_PUSH));
-            }
-        }
-            
-            template <typename T_Socket>
-            void connectToSocket(T_Socket& socket, std::string const signalingUri) {
-                socket.connect(signalingUri.c_str());
-                    
-            }
+  // Destructor
+  ~ZMQ() { SocketBase::deinit(); }
 
-            template <typename T_Socket>            
-	    void recvFromSocket(T_Socket& socket, std::stringstream& ss) {
-		::zmq::message_t message;                
-		socket.recv(&message);
-                ss << static_cast<char*>(message.data());
-	    }
+  /***********************************************************************/ /**
+    *
+    * @name Socket base utilities
+    *
+    * @{
+    *
+    ***************************************************************************/
 
-            template <typename T_Socket>            
-	    void recvFromSocket(T_Socket& socket, Message & message) {
-                socket.recv(&message.getMessage());                
-	    }
+  void createSocketsToPeers() {
+    for (auto const &vAddr : initialContext) {
+      (void)vAddr;
+      sendSockets.emplace_back(Socket(zmqContext, ZMQ_PUSH));
+      ctrlSendSockets.emplace_back(Socket(zmqContext, ZMQ_PUSH));
+    }
+  }
 
-            template <typename T_Socket>
-	    void sendToSocket(T_Socket& socket, std::stringstream const & ss) {
-                std::string string = ss.str();
-		::zmq::message_t message(sizeof(char) * string.size());
-		memcpy (static_cast<char*>(message.data()), string.data(), sizeof(char) * string.size());
-		socket.send(message);
-	    }
+  template <typename T_Socket>
+  void connectToSocket(T_Socket &socket, std::string const signalingUri) {
+    socket.connect(signalingUri.c_str());
+  }
 
-            template <typename T_Socket>
-	    void sendToSocket(T_Socket& socket, ::zmq::message_t & data) {
-                socket.send(data);
-            }
+  template <typename T_Socket>
+  void recvFromSocket(T_Socket &socket, std::stringstream &ss) {
+    ::zmq::message_t message;
+    socket.recv(&message);
+    ss << static_cast<char *>(message.data());
+  }
 
-	    Uri bindToNextFreePort(Socket &socket, const std::string peerUri){
-		std::string peerBaseUri = peerUri.substr(0, peerUri.rfind(":"));
-		unsigned peerBasePort   = std::stoi(peerUri.substr(peerUri.rfind(":") + 1));		
-		bool connected          = false;
+  template <typename T_Socket>
+  void recvFromSocket(T_Socket &socket, Message &message) {
+    socket.recv(&message.getMessage());
+  }
 
-		std::string uri;
-		while(!connected){
-                    try {
-                        uri = peerBaseUri + ":" + std::to_string(peerBasePort);
-                        socket.bind(uri.c_str());
-                        connected = true;
-                    }
-                    catch(::zmq::error_t e){
-			//std::cout << e.what() << ". PeerUri \"" << uri << "\". Try to increment port and rebind." << std::endl;
-                        peerBasePort++;
-                    }
-		    
-                }
+  template <typename T_Socket>
+  void sendToSocket(T_Socket &socket, std::stringstream const &ss) {
+    std::string string = ss.str();
+    ::zmq::message_t message(sizeof(char) * string.size());
+    memcpy(static_cast<char *>(message.data()), string.data(),
+           sizeof(char) * string.size());
+    socket.send(message);
+  }
 
-		return uri;
-		
-            }
-                
-	}; // class ZMQ
+  template <typename T_Socket>
+  void sendToSocket(T_Socket &socket, ::zmq::message_t &data) {
+    socket.send(data);
+  }
 
-    } // namespace communicationPolicy
-	
+  Uri bindToNextFreePort(Socket &socket, const std::string peerUri) {
+    std::string peerBaseUri = peerUri.substr(0, peerUri.rfind(":"));
+    unsigned peerBasePort = std::stoi(peerUri.substr(peerUri.rfind(":") + 1));
+    bool connected = false;
+
+    std::string uri;
+    while (!connected) {
+      try {
+        uri = peerBaseUri + ":" + std::to_string(peerBasePort);
+        socket.bind(uri.c_str());
+        connected = true;
+      } catch (::zmq::error_t e) {
+        // std::cout << e.what() << ". PeerUri \"" << uri << "\". Try to
+        // increment port and rebind." << std::endl;
+        peerBasePort++;
+      }
+    }
+
+    return uri;
+  }
+
+}; // class ZMQ
+} // namespace communicationPolicy
 } // namespace graybat

--- a/include/graybat/communicationPolicy/bmpi/Status.hpp
+++ b/include/graybat/communicationPolicy/bmpi/Status.hpp
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2016 Erik Zenker
+ *
+ * This file is part of Graybat.
+ *
+ * Graybat is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graybat is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Graybat.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <boost/mpi/environment.hpp>
+#include <boost/mpi/status.hpp>
+
+namespace graybat {
+namespace communicationPolicy {
+namespace bmpi {
+
+class Status {
+  using Tag = unsigned;
+  using VAddr = unsigned;
+
+public:
+  Status(boost::mpi::status status) : status(status){};
+  VAddr source() { return status.source(); }
+  Tag tag() { return status.tag(); }
+  template <typename T> std::size_t size() {
+    auto count = status.count<T>();
+    if (count) {
+      return *count;
+    } else {
+      assert(false);
+    }
+    return 0;
+  }
+
+private:
+  boost::mpi::status status;
+};
+
+} // namespace bmpi
+} // namespace communicationPolicy
+} // namespace graybat

--- a/include/graybat/communicationPolicy/zmq/Status.hpp
+++ b/include/graybat/communicationPolicy/zmq/Status.hpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2016 Erik Zenker
+ *
+ * This file is part of Graybat.
+ *
+ * Graybat is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graybat is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Graybat.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// STL
+#include <memory> /* std::unique_ptr */
+
+// graybat
+#include <graybat/communicationPolicy/Traits.hpp>
+
+namespace graybat {
+namespace communicationPolicy {
+namespace zmq {
+
+template <typename T_CP> class Status {
+    using VAddr = typename graybat::communicationPolicy::VAddr<T_CP>;
+    using Tag = typename graybat::communicationPolicy::Tag<T_CP>;
+public:
+  Status(VAddr vAddr, Tag tag, std::size_t size)
+      : vAddr_(vAddr), tag_(tag), size_(size) {}
+
+  VAddr source() { return vAddr_; }
+  Tag tag() { return tag_; }
+  template <typename T> std::size_t size() { return size_/sizeof(T); }
+
+private:
+    VAddr vAddr_;
+    Tag tag_;
+    std::size_t size_;
+};
+
+} // namespace zmq
+} // namespace communicationPolicy
+} // namespace graybat

--- a/include/graybat/utils/MultiKeyMap.hpp
+++ b/include/graybat/utils/MultiKeyMap.hpp
@@ -21,14 +21,14 @@
 #pragma once
 
 // STL
-#include <map>                /* std::map */
-#include <functional>         /* std::function */
+#include <atomic> /* std::atomic */
+#include <chrono> /* std::chrono::milliseconds */
 #include <condition_variable> /* std::condition_variable */
+#include <functional> /* std::function */
+#include <map> /* std::map */
 #include <mutex>              /* std::mutex, std::lock_guard, std::unique_lock*/
 #include <queue>              /* std::queue */
 #include <utility>            /* std::forward */
-#include <chrono>             /* std::chrono::milliseconds */
-#include <atomic>             /* std::atomic */
 
 // BOOST
 #include <boost/optional.hpp>
@@ -39,360 +39,388 @@ namespace hana = boost::hana;
 
 namespace utils {
 
-	template <typename... Tail> struct MultiKeyMapType;
+template <typename... Tail> struct MultiKeyMapType;
 
-	template <typename Key, typename Value>
-	struct MultiKeyMapType<Key, Value> {
-		typedef std::map<Key, Value> type;
-	};
+template <typename Key, typename Value> struct MultiKeyMapType<Key, Value> {
+    typedef std::map<Key, Value> type;
+};
 
-	template <typename Key, typename... Tail>
-	struct MultiKeyMapType<Key, Tail...>  {
-		typedef std::map<Key, typename MultiKeyMapType<Tail...>::type > type;
-	};
+template <typename Key, typename... Tail> struct MultiKeyMapType<Key, Tail...> {
+    typedef std::map<Key, typename MultiKeyMapType<Tail...>::type> type;
+};
 
+/**
+* @brief Collects all values of a map subtree into the values container and its
+*        corresponding keys into the key container
+*
+*/
+template <int KeysLeft> struct SubTreeValues {
 
-	/**
-     * @brief Collects all values of a map subtree into the values container and its
-     *        corresponding keys into the key container
-     *
+    template <typename T_Map, typename T_ValuesCT, typename T_KeysCT, typename T_Tuple>
+    void operator()(T_Map& map, T_ValuesCT& values, T_KeysCT& keys, T_Tuple& tuple)
+    {
+        auto begin = map.begin();
+        auto end = map.end();
+        for (auto it = begin; it != end; ++it) {
+            auto nextTuple = hana::concat(tuple, hana::make_tuple(it->first));
+            SubTreeValues<KeysLeft - 1>()(it->second, values, keys, nextTuple);
+        }
+    }
+
+    template <typename T_Map, typename T_ValuesCT, typename T_Keys>
+    void operator()(T_Map& map, T_ValuesCT& values, T_Keys& keys)
+    {
+        auto begin = map.begin();
+        auto end = map.end();
+        for (auto it = begin; it != end; ++it) {
+            auto t = hana::make_tuple(it->first);
+            SubTreeValues<KeysLeft - 1>()(it->second, values, keys, t);
+        }
+    }
+};
+
+template <> struct SubTreeValues<0> {
+
+    template <typename T_Value, typename T_ValuesCT, typename T_KeysCT, typename T_Tuple>
+    void operator()(T_Value& value, T_ValuesCT& values, T_KeysCT& keys, T_Tuple& tuple)
+    {
+        keys.push_back(tuple);
+        values.push_back(value);
+    }
+};
+
+/**
+* @brief Traverse through a map of map of ... and
+*        return the value of the last key.
+*
+*/
+auto at = [](auto& map, const auto& key) -> auto&
+{
+    return map[key];
+};
+
+template <typename T_Map, typename T_Keys> auto& traverse(T_Map& map, T_Keys const& keys)
+{
+    return hana::fold_left(keys, map, at);
+}
+
+/**
+* @brief A map with multiple keys, implemented by cascading several
+*        std::maps.
+*
+* The MultiKeyMap has the goal to provide the look and feel of
+* a usual std::map by the at and () methods. Furthermore, it
+* provides the possibility to retrieve the values of subtrees
+* by specifying not all keys by the values method.
+*
+*/
+template <typename T_Value, typename... T_Keys> struct MultiKeyMap {
+
+    typename MultiKeyMapType<T_Keys..., T_Value>::type multiKeyMap;
+
+    MultiKeyMap()
+    {
+    }
+
+    T_Value& operator()(const T_Keys... keys)
+    {
+        return traverse(multiKeyMap, hana::make_tuple(keys...));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// at
+    //////////////////////////////////////////////////////////////////////////////
+    template <typename T_KeysTpl> T_Value& at(const T_KeysTpl keysTuple)
+    {
+        return atImpl(keysTuple);
+    }
+
+    T_Value& at(const T_Keys... keys)
+    {
+        return atImpl(hana::make_tuple(keys...));
+    }
+
+    template <typename T_KeysTpl> T_Value& atImpl(const T_KeysTpl keysTuple)
+    {
+        auto firstKeysSize = hana::int_c<hana::minus(hana::int_c<hana::size(keysTuple)>, 1)>;
+        auto firstKeys = hana::take_front_c<firstKeysSize>(keysTuple);
+        auto lastKey = hana::back(keysTuple);
+
+        return traverse(multiKeyMap, firstKeys).at(lastKey);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// test
+    ///////////////////////////////////////////////////////////////////////////////
+    bool test(const T_Keys... keys)
+    {
+        return testImpl(hana::make_tuple(keys...));
+    }
+
+    template <typename T_KeysTpl> bool test(const T_KeysTpl keysTuple)
+    {
+        return testImpl(keysTuple);
+    }
+
+    template <typename T_KeysTpl> bool testImpl(const T_KeysTpl keysTuple)
+    {
+        auto firstKeysSize = hana::int_c<hana::minus(hana::int_c<hana::size(keysTuple)>, 1)>;
+        auto firstKeys = hana::take_front_c<firstKeysSize>(keysTuple);
+        auto lastKey = hana::back(keysTuple);
+
+        auto& subMap = traverse(multiKeyMap, firstKeys);
+        auto it = subMap.find(lastKey);
+        auto end = subMap.end();
+
+        return (it == end) ? false : true;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// erase
+    ///////////////////////////////////////////////////////////////////////////////
+    bool erase(const T_Keys... keys)
+    {
+        return eraseImpl(hana::make_tuple(keys...));
+    }
+
+    template <typename T_KeysTPL> bool erase(const T_KeysTPL keysTuple)
+    {
+        return eraseImpl(keysTuple);
+    }
+
+    template <typename T_KeysTpl> bool eraseImpl(const T_KeysTpl keysTuple)
+    {
+        auto firstKeysSize = hana::int_c<hana::minus(hana::int_c<hana::size(keysTuple)>, 1)>;
+        auto firstKeys = hana::take_front_c<firstKeysSize>(keysTuple);
+        auto lastKey = hana::back(keysTuple);
+
+        auto& lastMap = traverse(multiKeyMap, firstKeys);
+        auto it = lastMap.find(lastKey);
+        auto end = lastMap.end();
+
+        if (it == end)
+            return false;
+        else {
+            lastMap.erase(it);
+            return true;
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// values
+    ///////////////////////////////////////////////////////////////////////////////
+    template <typename T_ValuesCT, typename T_KeysCT> void values(T_Value& values, T_KeysCT& keys)
+    {
+        constexpr size_t keysTupleSize = std::tuple_size<std::tuple<T_Keys...>>::value;
+        SubTreeValues<keysTupleSize>()(multiKeyMap, values, keys);
+    }
+
+    template <typename T_ValuesCT, typename T_KeysCT, typename... T_Sub_Keys>
+    void values(T_ValuesCT& values, T_KeysCT& keys, const T_Sub_Keys... subKeys)
+    {
+        constexpr size_t subKeysTupleSize = std::tuple_size<std::tuple<T_Sub_Keys...>>::value;
+        constexpr size_t keysTupleSize = std::tuple_size<std::tuple<T_Keys...>>::value;
+        constexpr size_t subTreeSize = keysTupleSize - subKeysTupleSize;
+        auto tuple = hana::make_tuple(subKeys...);
+        SubTreeValues<subTreeSize>()(traverse(multiKeyMap, tuple), values, keys, tuple);
+    }
+};
+
+template <typename T_Value, typename... T_Keys> struct MessageBox {
+
+    MessageBox(size_t const maxBufferSize)
+        : maxBufferSize(maxBufferSize)
+        , bufferSize(0)
+    {
+    }
+
+    size_t maxBufferSize;
+    std::atomic<size_t> bufferSize;
+    std::mutex access;
+    std::mutex writeNotify;
+    std::mutex readNotify;
+    std::condition_variable writeCondition;
+    std::condition_variable readCondition;
+
+    using Queue = std::queue<T_Value>;
+    MultiKeyMap<Queue, T_Keys...> multiKeyMap;
+
+    auto enqueue(T_Value&& value, const T_Keys... keys) -> void
+    {
+        {
+            while (maxBufferSize < bufferSize + value.size()) {
+                std::unique_lock<std::mutex> notifyLock(readNotify);
+                readCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
+            }
+
+            bufferSize += value.size();
+            // std::cout << bufferSize << std::endl;
+            // std::cout << "Try to enqueue message." << std::endl;
+            std::lock_guard<std::mutex> accessLock(access);
+            multiKeyMap(keys...).push(std::forward<T_Value>(value));
+        }
+        // std::cout << "notify on condition variable." << std::endl;
+        writeCondition.notify_one();
+    }
+
+    auto waitDequeue(const T_Keys... keys) -> T_Value
+    {
+
+        bool test = false;
+
+        {
+            std::lock_guard<std::mutex> accessLock(access);
+            test = !multiKeyMap.test(keys...);
+        }
+
+        while (test) {
+            std::unique_lock<std::mutex> notifyLock(writeNotify);
+            // std::cout << "wait for multikeymap enqueue." << std::endl;
+            writeCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
+            {
+                std::lock_guard<std::mutex> accessLock(access);
+                test = !multiKeyMap.test(keys...);
+            }
+        }
+
+        while (multiKeyMap.at(keys...).empty()) {
+            std::unique_lock<std::mutex> notifyLock(writeNotify);
+            // std::cout << "wait for queue to be filled." << std::endl;
+            writeCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
+        }
+
+        {
+            std::lock_guard<std::mutex> accessLock(access);
+            // std::cout << "get message from queue" << std::endl;
+            T_Value value = std::move(multiKeyMap.at(keys...).front());
+            multiKeyMap.at(keys...).pop();
+            bufferSize -= value.size();
+            readCondition.notify_one();
+            return value;
+        }
+    }
+
+    template <typename... SubKeys>
+    auto waitDequeue(hana::tuple<T_Keys...>& allKeys, const SubKeys... someKeys) -> T_Value
+    {
+
+        while (true) {
+
+            std::vector<std::reference_wrapper<Queue>> values;
+            std::vector<hana::tuple<T_Keys...>> keysList;
+            while (values.empty()) {
+                std::unique_lock<std::mutex> notifyLock(writeNotify);
+                {
+                    std::lock_guard<std::mutex> accessLock(access);
+                    multiKeyMap.values(values, keysList, someKeys...);
+                }
+                writeCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
+            }
+
+            {
+                std::lock_guard<std::mutex> accessLock(access);
+                for (auto& keys : keysList) {
+                    auto& queue = multiKeyMap.at(keys);
+                    if (!queue.empty()) {
+                        allKeys = keys;
+                        T_Value value = std::move(queue.front());
+                        queue.pop();
+                        bufferSize -= value.size();
+                        readCondition.notify_one();
+                        return value;
+                    }
+                }
+            }
+            std::unique_lock<std::mutex> notifyLock(writeNotify);
+            writeCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
+        }
+    }
+
+    auto tryDequeue(bool& result, const T_Keys... keys) -> T_Value
+    {
+
+        {
+            std::lock_guard<std::mutex> accessLock(access);
+            if (!multiKeyMap.test(keys...)) {
+                result = false;
+                return T_Value();
+            }
+        }
+
+        if (multiKeyMap.at(keys...).empty()) {
+            result = false;
+            return T_Value();
+        }
+
+        {
+            std::lock_guard<std::mutex> accessLock(access);
+            // std::cout << "get message from queue" << std::endl;
+            T_Value value = std::move(multiKeyMap.at(keys...).front());
+            multiKeyMap.at(keys...).pop();
+            bufferSize -= value.size();
+            readCondition.notify_one();
+            result = true;
+            return value;
+        }
+    }
+
+    auto waitProbe(const T_Keys... keys) -> std::size_t
+    {
+
+        bool test = false;
+
+        {
+            std::lock_guard<std::mutex> accessLock(access);
+            test = !multiKeyMap.test(keys...);
+        }
+
+        while (test) {
+            std::unique_lock<std::mutex> notifyLock(writeNotify);
+            // std::cout << "wait for multikeymap enqueue." <<
+            // std::endl;
+            writeCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
+            {
+                std::lock_guard<std::mutex> accessLock(access);
+                test = !multiKeyMap.test(keys...);
+            }
+        }
+
+        while (multiKeyMap.at(keys...).empty()) {
+            std::unique_lock<std::mutex> notifyLock(writeNotify);
+            // std::cout << "wait for queue to be filled." << std::endl;
+            writeCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
+        }
+
+        {
+            std::lock_guard<std::mutex> accessLock(access);
+            return multiKeyMap.at(keys...).front().size();
+        }
+    }
+
+    /**
+     * @brief Estimates the size of a message with specified keys if available,otherwise return 0.
+     * @param keys
+     * @return size of message in the inbox
      */
-	template <int KeysLeft>
-	struct SubTreeValues {
-
-		template <typename T_Map, typename T_ValuesCT, typename T_KeysCT, typename T_Tuple>
-		void operator()(T_Map &map, T_ValuesCT & values, T_KeysCT& keys, T_Tuple & tuple){
-			auto begin = map.begin();
-			auto end   = map.end();
-			for(auto it = begin; it != end; ++it){
-				auto nextTuple = hana::concat(tuple, hana::make_tuple(it->first));
-				SubTreeValues<KeysLeft-1>()(it->second, values, keys, nextTuple);
-			}
-
-		}
-
-		template <typename T_Map, typename T_ValuesCT, typename T_Keys>
-		void operator()(T_Map &map, T_ValuesCT &values, T_Keys& keys){
-			auto begin = map.begin();
-			auto end   = map.end();
-			for(auto it = begin; it != end; ++it){
-				auto t = hana::make_tuple(it->first);
-				SubTreeValues<KeysLeft-1>()(it->second, values, keys, t);
-			}
-
-		}
-
-	};
-
-	template <>
-	struct SubTreeValues <0> {
-
-		template <typename T_Value, typename T_ValuesCT, typename T_KeysCT, typename T_Tuple>
-		void operator()(T_Value &value, T_ValuesCT& values, T_KeysCT& keys, T_Tuple &tuple){
-			keys.push_back(tuple);
-			values.push_back(value);
-		}
-
-	};
-
-	/**
-     * @brief Traverse through a map of map of ... and 
-     *        return the value of the last key.
-     *
-     */
-	auto at = [] (auto &map,  const auto &key) -> auto& {
-		return map[key];
-	};
-
-
-	template <typename T_Map, typename T_Keys>
-	auto& traverse(T_Map& map, T_Keys const& keys) {
-		return hana::fold_left(keys, map, at);
-	}
-
-
-
-	/**
-     * @brief A map with multiple keys, implemented by cascading several 
-     *        std::maps.
-     *
-     * The MultiKeyMap has the goal to provide the look and feel of
-     * a usual std::map by the at and () methods. Furthermore, it
-     * provides the possibility to retrieve the values of subtrees
-     * by specifying not all keys by the values method.
-     *
-     */
-	template <typename T_Value, typename... T_Keys>
-	struct MultiKeyMap {
-
-		typename MultiKeyMapType<T_Keys..., T_Value>::type multiKeyMap;
-
-		MultiKeyMap() {
-
-		}
-
-		T_Value& operator()(const T_Keys... keys){
-			return traverse(multiKeyMap, hana::make_tuple(keys...));
-		}
-
-		/***************************************************************************
-             * at
-             ***************************************************************************/
-		template <typename T_KeysTpl>
-		T_Value& at(const T_KeysTpl keysTuple){
-			return atImpl(keysTuple);
-		}
-
-
-		T_Value& at(const T_Keys... keys){
-			return atImpl(hana::make_tuple(keys...));
-
-		}
-
-		template <typename T_KeysTpl>
-		T_Value& atImpl(const T_KeysTpl keysTuple){
-			auto firstKeysSize = hana::int_c<hana::minus(hana::int_c<hana::size(keysTuple)>, 1)>;
-			auto firstKeys     = hana::take_front_c<firstKeysSize>(keysTuple);
-			auto lastKey       = hana::back(keysTuple);
-
-
-			return traverse(multiKeyMap, firstKeys).at(lastKey);
-		}
-
-		/***************************************************************************
-             * test
-             ***************************************************************************/
-		bool test(const T_Keys ...keys) {
-			return testImpl(hana::make_tuple(keys...));
-		}
-
-		template <typename T_KeysTpl>
-		bool test(const T_KeysTpl keysTuple) {
-			return testImpl(keysTuple);
-		}
-
-
-		template <typename T_KeysTpl>
-		bool testImpl(const T_KeysTpl keysTuple) {
-			auto firstKeysSize = hana::int_c<hana::minus(hana::int_c<hana::size(keysTuple)>, 1)>;
-			auto firstKeys     = hana::take_front_c<firstKeysSize>(keysTuple);
-			auto lastKey       = hana::back(keysTuple);
-
-			auto &subMap = traverse(multiKeyMap, firstKeys);
-			auto it  = subMap.find(lastKey);
-			auto end = subMap.end();
-
-			return (it == end) ? false : true;
-
-		}
-
-		/***************************************************************************
-             * erase
-             ***************************************************************************/
-		bool erase(const T_Keys ...keys) {
-			return eraseImpl(hana::make_tuple(keys...));
-		}
-
-		template <typename T_KeysTPL>
-		bool erase(const T_KeysTPL keysTuple) {
-			return eraseImpl(keysTuple);
-		}
-
-
-		template <typename T_KeysTpl>
-		bool eraseImpl(const T_KeysTpl keysTuple) {
-			auto firstKeysSize = hana::int_c<hana::minus(hana::int_c<hana::size(keysTuple)>, 1)>;
-			auto firstKeys     = hana::take_front_c<firstKeysSize>(keysTuple);
-			auto lastKey       = hana::back(keysTuple);
-
-
-			auto &lastMap = traverse(multiKeyMap, firstKeys);
-			auto it  = lastMap.find(lastKey);
-			auto end = lastMap.end();
-
-			if(it == end) return false;
-			else {
-				lastMap.erase(it);
-				return true;
-			}
-
-		}
-
-
-		/***************************************************************************
-             * values
-             ***************************************************************************/
-		template <typename T_ValuesCT, typename T_KeysCT>
-		void values(T_Value &values, T_KeysCT& keys){
-			constexpr size_t keysTupleSize = std::tuple_size<std::tuple<T_Keys...>>::value;
-			SubTreeValues<keysTupleSize>()(multiKeyMap, values, keys);
-		}
-
-		template <typename T_ValuesCT, typename T_KeysCT, typename ...T_Sub_Keys>
-		void values(T_ValuesCT &values, T_KeysCT& keys, const T_Sub_Keys... subKeys){
-			constexpr size_t subKeysTupleSize = std::tuple_size<std::tuple<T_Sub_Keys...>>::value;
-			constexpr size_t keysTupleSize    = std::tuple_size<std::tuple<T_Keys...>>::value;
-			constexpr size_t subTreeSize      = keysTupleSize - subKeysTupleSize;
-			auto tuple = hana::make_tuple(subKeys...);
-			SubTreeValues<subTreeSize>()(traverse(multiKeyMap, tuple), values, keys, tuple);
-
-		}
-
-	};
-
-
-	template <typename T_Value, typename... T_Keys>
-	struct MessageBox {
-
-		MessageBox(size_t const maxBufferSize) :
-				maxBufferSize(maxBufferSize),
-				bufferSize(0){
-		}
-
-		size_t maxBufferSize;
-		std::atomic<size_t> bufferSize;
-		std::mutex access;
-		std::mutex writeNotify;
-		std::mutex readNotify;
-		std::condition_variable writeCondition;
-		std::condition_variable readCondition;
-
-		using Queue = std::queue<T_Value>;
-		MultiKeyMap<Queue, T_Keys...> multiKeyMap;
-
-		auto enqueue(T_Value&& value, const T_Keys... keys) -> void {
-			{
-				while(maxBufferSize < bufferSize + value.size()){
-					std::unique_lock<std::mutex> notifyLock(readNotify);
-					readCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
-				}
-
-				bufferSize += value.size();
-				//std::cout << bufferSize << std::endl;
-				//std::cout << "Try to enqueue message." << std::endl;
-				std::lock_guard<std::mutex> accessLock(access);
-				multiKeyMap(keys...).push(std::forward<T_Value>(value));
-			}
-			//std::cout << "notify on condition variable." << std::endl;
-			writeCondition.notify_one();
-		}
-
-		auto waitDequeue(const T_Keys... keys) -> T_Value {
-
-			bool test = false;
-
-			{
-				std::lock_guard<std::mutex> accessLock(access);
-				test = !multiKeyMap.test(keys...);
-			}
-
-			while(test){
-				std::unique_lock<std::mutex> notifyLock(writeNotify);
-				//std::cout << "wait for multikeymap enqueue." << std::endl;
-				writeCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
-				{
-					std::lock_guard<std::mutex> accessLock(access);
-					test = !multiKeyMap.test(keys...);
-				}
-
-			}
-
-			while(multiKeyMap.at(keys...).empty()){
-				std::unique_lock<std::mutex> notifyLock(writeNotify);
-				//std::cout << "wait for queue to be filled." << std::endl;
-				writeCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
-
-			}
-
-			{
-				std::lock_guard<std::mutex> accessLock(access);
-				//std::cout << "get message from queue" << std::endl;
-				T_Value value = std::move(multiKeyMap.at(keys...).front());
-				multiKeyMap.at(keys...).pop();
-				bufferSize -= value.size();
-				readCondition.notify_one();
-				return value;
-			}
-
-		}
-
-		template <typename... SubKeys>
-		auto waitDequeue(hana::tuple<T_Keys...> &allKeys, const SubKeys... someKeys) -> T_Value {
-
-			while(true){
-
-				std::vector<std::reference_wrapper<Queue>> values;
-				std::vector<hana::tuple<T_Keys...> > keysList;
-				while(values.empty()){
-					std::unique_lock<std::mutex> notifyLock(writeNotify);
-					{
-						std::lock_guard<std::mutex> accessLock(access);
-						multiKeyMap.values(values, keysList, someKeys...);
-
-					}
-					writeCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
-				}
-
-				{
-					std::lock_guard<std::mutex> accessLock(access);
-					for(auto &keys : keysList ){
-						auto& queue = multiKeyMap.at(keys);
-						if(!queue.empty()) {
-							allKeys = keys;
-							T_Value value = std::move(queue.front());
-							queue.pop();
-							bufferSize -= value.size();
-							readCondition.notify_one();
-							return value;
-						}
-
-					}
-				}
-				std::unique_lock<std::mutex> notifyLock(writeNotify);
-				writeCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
-
-			}
-
-		}
-
-		auto tryDequeue(bool &result, const T_Keys... keys) -> T_Value {
-
-			{
-				std::lock_guard<std::mutex> accessLock(access);
-				if(!multiKeyMap.test(keys...)){
-					result = false;
-					return T_Value();
-				}
-			}
-
-			if(multiKeyMap.at(keys...).empty()){
-				result = false;
-				return T_Value();
-			}
-
-			// //while(test){
-			//     std::unique_lock<std::mutex> notifyLock(writeNotify);
-			//     //std::cout << "wait for multikeymap enqueue." << std::endl;
-			//     writeCondition.wait_for(notifyLock, std::chrono::milliseconds(100));
-			//     {
-			//         std::lock_guard<std::mutex> accessLock(access);
-			//         test = !multiKeyMap.test(keys...);
-			//     }
-			//     //}
-
-			{
-				std::lock_guard<std::mutex> accessLock(access);
-				//std::cout << "get message from queue" << std::endl;
-				T_Value value = std::move(multiKeyMap.at(keys...).front());
-				multiKeyMap.at(keys...).pop();
-				bufferSize -= value.size();
-				readCondition.notify_one();
-				result = true;
-				return value;
-			}
-
-		}
-
-	};
+    auto tryProbe(const T_Keys... keys) -> std::size_t
+    {
+
+        {
+            std::lock_guard<std::mutex> accessLock(access);
+            if (!multiKeyMap.test(keys...)) {
+                return 0;
+            }
+        }
+
+        if (multiKeyMap.at(keys...).empty()) {
+            return 0;
+        }
+
+        {
+            std::lock_guard<std::mutex> accessLock(access);
+            return multiKeyMap.at(keys...).front().size();
+        }
+    }
+};
 
 } /* utils */


### PR DESCRIPTION
Adds a `probe` method to the communication policy interface with the following signature:
```c++
struct Status {
 VAddr source();
 Tag tag();
 template<typename T> std::size_t size();
}

Status probe(VAddr srcVAddr, Tag tag, const Context& context) ;
```
`probe` blocks until a message for the particular vAddr, tag and context was received. It returns a status object once a message is received.