### PR TITLE
Make mpi and zmq/grpc optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,54 +86,60 @@ endif(CCACHE_FOUND)
 
 # Benchmark
 file(GLOB BENCHMARKS test/benchmark/*.cpp)
-add_executable(benchmark EXCLUDE_FROM_ALL ${BENCHMARKS} ${graybat_GENERATED_FILES})
+add_executable(benchmark ${BENCHMARKS} ${graybat_GENERATED_FILES})
 target_link_libraries(benchmark ${LIBS})
 
 # Test cases
 file(GLOB INTEGRATION_TESTS test/integration/*.cpp)
-add_executable(check EXCLUDE_FROM_ALL ${INTEGRATION_TESTS} ${graybat_GENERATED_FILES})
+add_executable(check ${INTEGRATION_TESTS} ${graybat_GENERATED_FILES})
+target_compile_definitions(check PRIVATE ${graybat_DEFINITIONS})
 target_link_libraries(check ${LIBS})
+add_test(graybat_check_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target check)
+add_test(graybat_test_run_2_peers  mpiexec -n 2 check )
+set_tests_properties(graybat_test_run_2_peers PROPERTIES DEPENDS graybat_check_build)
 
 file(GLOB UNIT_TESTS test/unit/main.cpp test/unit/*Tests.cpp)
-add_executable(unit_tests EXCLUDE_FROM_ALL ${UNIT_TESTS} ${graybat_GENERATED_FILES})
+add_executable(unit_tests ${UNIT_TESTS} ${graybat_GENERATED_FILES})
 target_link_libraries(unit_tests ${LIBS})
+add_test(graybat_unit_tests_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target unit_tests)
+add_test(graybat_unit_tests_run unit_tests )
+set_tests_properties(graybat_unit_tests_run PROPERTIES DEPENDS graybat_unit_tests_build)
 
 # Fast testing
-file(GLOB TESTSFAST test/integration/main.cpp test/unit/ThreadPoolTests.cpp)
-add_executable(checkFast EXCLUDE_FROM_ALL ${TESTSFAST} ${graybat_GENERATED_FILES})
-set_property(TARGET checkFast PROPERTY CXX_STANDARD 14)
-target_link_libraries(checkFast ${LIBS})
+#file(GLOB TESTSFAST test/integration/main.cpp test/unit/ThreadPoolTests.cpp)
+#add_executable(checkFast EXCLUDE_FROM_ALL ${TESTSFAST} ${graybat_GENERATED_FILES})
+#set_property(TARGET checkFast PROPERTY CXX_STANDARD 14)
+#target_link_libraries(checkFast ${LIBS})
 
 # Examples
-add_custom_target(example)
-file(GLOB EXAMPLES  example/*.cpp)
-foreach(EXAMPLE ${EXAMPLES})
+if(graybat_BMPI_CP_ENABLED)
+  add_custom_target(example)
+  file(GLOB EXAMPLES  example/*.cpp)
+  foreach(EXAMPLE ${EXAMPLES})
 	get_filename_component(DEP ${EXAMPLE} NAME_WE)
-	add_executable(${DEP} EXCLUDE_FROM_ALL ${EXAMPLE} ${graybat_GENERATED_FILES})
+	add_executable(${DEP} ${EXAMPLE} ${graybat_GENERATED_FILES})
     set_property(TARGET ${DEP} PROPERTY CXX_STANDARD 14)
 	target_link_libraries(${DEP} LINK_INTERFACE_LIBRARIES graybat)
 	target_link_libraries(${DEP} ${LIBS})
 	add_dependencies(example ${DEP})
-endforeach(EXAMPLE)
+  endforeach(EXAMPLE)
+
+  add_test(graybat_example_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target example)
+  add_test(graybat_gol_run  mpiexec gol 90 4 )
+  add_test(graybat_pr_run  mpiexec pagerank )
+  set_tests_properties(graybat_gol_run PROPERTIES DEPENDS graybat_example_build)
+  set_tests_properties(graybat_pr_run PROPERTIES DEPENDS graybat_example_build)
+endif()
 
 # GRPC signaling server
-add_executable( signaling EXCLUDE_FROM_ALL utils/signaling_server.cpp ${graybat_GENERATED_FILES})
-set_property(TARGET signaling PROPERTY CXX_STANDARD 11)
-target_link_libraries(signaling ${LIBS})
+if(graybat_ZMQ_CP_ENABLED)
+  add_executable( signaling utils/signaling_server.cpp ${graybat_GENERATED_FILES})
+  set_property(TARGET signaling PROPERTY CXX_STANDARD 11)
+  target_link_libraries(signaling ${LIBS})
+endif()
 
 # CTest
 enable_testing()
-add_test(graybat_unit_tests_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target unit_tests)
-add_test(graybat_check_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target check)
-add_test(graybat_example_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target example)
-add_test(graybat_test_run_2_peers  mpiexec -n 2 check )
-add_test(graybat_gol_run  mpiexec gol 90 4 )
-add_test(graybat_pr_run  mpiexec pagerank )
-add_test(graybat_unit_tests_run unit_tests )
-set_tests_properties(graybat_test_run_2_peers PROPERTIES DEPENDS graybat_check_build)
-set_tests_properties(graybat_gol_run PROPERTIES DEPENDS graybat_example_build)
-set_tests_properties(graybat_pr_run PROPERTIES DEPENDS graybat_example_build)
-set_tests_properties(graybat_unit_tests_run PROPERTIES DEPENDS graybat_unit_tests_build)
 
 # Install
 file(GLOB CMAKE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.cmake")
@@ -148,15 +154,17 @@ install(
   DESTINATION "lib/graybat"
 )
 
+if(graybat_ZMQ_CP_ENABLED)
 install( TARGETS signaling
           RUNTIME DESTINATION "bin"
         )
+endif()
 
 # Doxygen
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doxygen.conf ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-  add_custom_target(doc 
+  add_custom_target(doc
     COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Graybat
 Schemes <b>B</b>ased on <b>A</b>daptive <b>T</b>opologies
 
 
-##Description##
+##Descriptio
 
 **Graybat** is a C++ library that presents a graph-based communication
 approach, which enables a mapping of algorithms to communication
@@ -19,23 +19,23 @@ adptable during run-time.
 The graybat API is currently unstable.
 
 
-##Documentation##
+##Documentation
 
 Have a look at the documentation that is available [here](https://ComputationalRadiationPhysics.github.io/graybat) or
 skim through the [examples](example) or [test cases](test) to have a quick start into graybat.
 
 
-##Referencing##
+##Referencing
 
 Graybat is a scientific project. If you **present and/or publish** scientific
 results that used graybat, you should set this as a **reference**.
 
-##Software License##
+##Software License
 
 Graybat is licensed under the <b>LGPLv3+</b>. Please refer to our [LICENSE.md](LICENSE.md)
 
 
-##Project Organization##
+##Project Organization
 
 The project is organized in a couple of subdirectories.
 
@@ -45,29 +45,29 @@ The project is organized in a couple of subdirectories.
  * The [utils](utils) directory contains cmake modules and doxygen files.
 
 
-##Dependencies##
+##Dependencies
 
-###Mandatory###
+###Mandatory
  * cmake 3.0.2
  * Boost 1.61.0
  * g++ 6.0.0 or clang 3.5
  * c++14
 
-###Optional###
+###Optional
  * OpenMPI 1.8.0 (mpi communication policy)
  * zeromq 4.1.3 (zeromq communication policy) 
  * metis 5.1 (graph partitioning mapping)
 
 
-##Roadmap##
+##Roadmap
  * [Dynamic context](https://github.com/ComputationalRadiationPhysics/graybat/milestones/Dynamic%20Context)
  * [Boost::Asio communication policy](https://github.com/ComputationalRadiationPhysics/graybat/milestones/Boost::Asio%20Communication%20Policy)
  * [C++11 thread communication policy](https://github.com/ComputationalRadiationPhysics/graybat/milestones/C++11%20Threads%20Communication%20Policy)
 
 
-##Installation##
+##Installation
 
-###System Installion###
+###System Installion
 
 Installation into the operating system libery path e.g.
 to `/usr/lib/graybat`:
@@ -77,14 +77,14 @@ to `/usr/lib/graybat`:
 	cmake -DCMAKE_INSTALL_DIR=/usr ..
 	sudo make install
 	
-###Package Install###
+###Package Install
 
 * Graybat [AUR package](https://aur.archlinux.org/packages/graybat-git/)
 
-##Usage as Library##
+##Usage as Library
 
 
-###CMAKE-Configfile###
+###CMAKE-Configfile
 Graybat is a header only library so nothing has to be build.  The most
 easy way to include graybat into your application is to use the shiped
 [CMAKE-Configfile](https://cmake.org/cmake/help/v3.4/manual/cmake-packages.7.html#config-file-packages),
@@ -101,9 +101,10 @@ or by setting the `graybat_DIR`:
 
 
 The CMAKE-Configfile of graybat provides the CMAKE variables `${graybat_INCLUDE_DIRS}`,
-`${graybat_LIBRARIES}`, and `${graybat_GENERATED_FILES}`. Where `${graybat_INCLUDE_DIRS}` contains all header files
-included by graybat,`${graybat_LIBRARIES}` contains all libraries used by graybat, and `${graybat_GENERATED_FILES}`
-contains all generated files that need to be compiled with the target.
+`${graybat_LIBRARIES}`, `${graybat_GENERATED_FILES}`, and `${graybat_DEFINITIONS}`. Where `${graybat_INCLUDE_DIRS}` contains all header files
+included by graybat,`${graybat_LIBRARIES}` contains all libraries used by graybat, `${graybat_GENERATED_FILES}`
+contains all generated files that need to be compiled with the target, and `${graybat_DEFINITIONS}` contains compile time definitions which can be
+used to toggle policies.
 The following is a an example of how to embed graybat into your `CMakeLists.txt`
 
      find_package(graybat REQUIRED CONFIG)
@@ -111,12 +112,13 @@ The following is a an example of how to embed graybat into your `CMakeLists.txt`
      set(LIBS ${LIBS} ${graybat_LIBRARIES})
   
      add_executable(myTarget main.cpp ${graybat_GENERATED_FILES})
+     target_compile_definitions(myTarget PRIVATE ${graybat_DEFINITIONS})
      target_link_libraries(signaling ${LIBS})
 
-Finally, the application can use graybat e.g. `#include <graybat/Cage.hpp>`.
+Finally, the application can use graybat e.g. `#include <graybat/graybat.hpp>`.
 
 
-##Compiling Tests/Examples##
+##Compiling Tests/Examples
 
  * Clone the repository: `git clone https://github.com/computationalradiationphysics/graybat.git`
  * Change directory: `cd graybat`
@@ -126,7 +128,7 @@ Finally, the application can use graybat e.g. `#include <graybat/Cage.hpp>`.
  * Create Makefile `cmake ..`
  * Build project : `make [target]`
 
-##Benchmarks##
+##Benchmarks
 There exist benchmarks for graybat:
 ```
 make benchmark
@@ -155,7 +157,7 @@ meassureSingleMessageSendZmq/976.562k    23033162 ns   22561309 ns         31
 ```
 
 
-##Predefined Targets##
+##Predefined Targets
 
  * **example**: All example applications.
 
@@ -170,17 +172,17 @@ meassureSingleMessageSendZmq/976.562k    23033162 ns   22561309 ns         31
  * **clean**: Cleanup build directory.
 
 
-##Tested Compilers##
+##Tested Compilers
 
  * clang 3.5
  * g++ 5.2.0
 
 
-##Related Material##
+##Related Material
  * Talk by Erik Zenker of his diploma defence [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.16306.svg)](http://dx.doi.org/10.5281/zenodo.16306)
 
 
-##Authors##
+##Authors
 
  * Erik Zenker (erikzenker@posteo.de)
 

--- a/example/anyrecv.cpp
+++ b/example/anyrecv.cpp
@@ -32,18 +32,8 @@
 #include <functional> /* std::bind */
 
 // GRAYBAT
-#include <graybat/Cage.hpp>
+#include <graybat/graybat.hpp>
 #include <graybat/communicationPolicy/BMPI.hpp>
-#include <graybat/graphPolicy/BGL.hpp>
-#include <graybat/serializationPolicy/ByteCast.hpp>
-// GRAYBAT mappings
-#include <graybat/mapping/Consecutive.hpp>
-#include <graybat/mapping/Random.hpp>
-#include <graybat/mapping/Roundrobin.hpp>
-// GRAYBAT pattern
-#include <graybat/pattern/GridDiagonal.hpp>
-#include <graybat/pattern/Chain.hpp>
-#include <graybat/pattern/BiStar.hpp>
 
 struct Function {
     
@@ -79,7 +69,6 @@ int exp() {
     /***************************************************************************
      * Initialize Communication
      ****************************************************************************/
-    // Create GoL Graph
     Config config;
     Cage cage(config);
 

--- a/example/chain.cpp
+++ b/example/chain.cpp
@@ -36,18 +36,8 @@
 #include <numeric>    /* std::accumulate */
 
 // GRAYBAT
-#include <graybat/Cage.hpp>
+#include <graybat/graybat.hpp>
 #include <graybat/communicationPolicy/BMPI.hpp>
-#include <graybat/graphPolicy/BGL.hpp>
-#include <graybat/serializationPolicy/ByteCast.hpp>
-// GRAYBAT mappings
-#include <graybat/mapping/Consecutive.hpp>
-#include <graybat/mapping/Random.hpp>
-#include <graybat/mapping/Roundrobin.hpp>
-#include <graybat/mapping/Filter.hpp>
-// GRAYBAT pattern
-#include <graybat/pattern/Chain.hpp>
-
 
 struct Tag {
     std::size_t tag;
@@ -80,7 +70,6 @@ int exp() {
     const unsigned nChainLinks = 6;
     auto inc = [](unsigned &a){a++;};
 
-    // Create GoL Graph
     Config config;
     Cage cage(config);
 

--- a/example/forward.cpp
+++ b/example/forward.cpp
@@ -33,17 +33,8 @@
 #include <functional> /* std::bind */
 
 // GRAYBAT
-#include <graybat/Cage.hpp>
+#include <graybat/graybat.hpp>
 #include <graybat/communicationPolicy/BMPI.hpp>
-#include <graybat/graphPolicy/BGL.hpp>
-#include <graybat/serializationPolicy/ByteCast.hpp>
-// GRAYBAT mappings
-#include <graybat/mapping/Consecutive.hpp>
-#include <graybat/mapping/Random.hpp>
-#include <graybat/mapping/Roundrobin.hpp>
-// GRAYBAT pattern
-#include <graybat/pattern/GridDiagonal.hpp>
-#include <graybat/pattern/Chain.hpp>
 
 struct Function {
     
@@ -82,7 +73,6 @@ int exp() {
 nn     ****************************************************************************/
     const unsigned nChainLinks = 1000;
     
-    // Create GoL Graph
     Config config;
     Cage cage(config);
 

--- a/example/gol.cpp
+++ b/example/gol.cpp
@@ -35,16 +35,8 @@
 #include <numeric>    /* std::accumulate */
 
 // GRAYBAT
-#include <graybat/Cage.hpp>
+#include <graybat/graybat.hpp>
 #include <graybat/communicationPolicy/BMPI.hpp>
-#include <graybat/graphPolicy/BGL.hpp>
-#include <graybat/serializationPolicy/ByteCast.hpp>
-// GRAYBAT mappings
-#include <graybat/mapping/Consecutive.hpp>
-#include <graybat/mapping/Random.hpp>
-#include <graybat/mapping/Roundrobin.hpp>
-// GRAYBAT patterns
-#include <graybat/pattern/GridDiagonal.hpp>
 
 struct Cell {
     Cell() : isAlive{{0}}, aliveNeighbors(0){
@@ -118,7 +110,7 @@ int gol(const unsigned nCells, const unsigned nTimeSteps ) {
 
     // CommunicationPolicy
     typedef graybat::communicationPolicy::BMPI CP;
-    
+
     // GraphPolicy
     typedef graybat::graphPolicy::BGL<Cell>    GP;
 

--- a/example/pagerank.cpp
+++ b/example/pagerank.cpp
@@ -37,10 +37,7 @@
 #include <graybat/serializationPolicy/ByteCast.hpp>
 
 // GRAYBAT mappings
-#include <graybat/mapping/Consecutive.hpp>
-
-// GRAYBAT pattern
-#include <graybat/pattern/Random.hpp>
+#include <graybat/graybat.hpp>
 
 struct PageRank {
     PageRank() : pageRank({1}){ }

--- a/example/ring.cpp
+++ b/example/ring.cpp
@@ -32,16 +32,8 @@
 #include <array>      /* std::array */
 
 // GRAYBAT
-#include <graybat/Cage.hpp>
+#include <graybat/graybat.hpp>
 #include <graybat/communicationPolicy/BMPI.hpp>
-#include <graybat/graphPolicy/BGL.hpp>
-#include <graybat/serializationPolicy/ByteCast.hpp>
-// GRAYBAT mappings
-#include <graybat/mapping/Consecutive.hpp>
-#include <graybat/mapping/Random.hpp>
-#include <graybat/mapping/Roundrobin.hpp>
-// GRAYBAT patterns
-#include <graybat/pattern/Ring.hpp>
 
 struct Function {
 

--- a/include/graybat/graybat.hpp
+++ b/include/graybat/graybat.hpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2016 Erik Zenker
+ *
+ * This file is part of Graybat.
+ *
+ * Graybat is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graybat is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Graybat.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <graybat/Cage.hpp>
+
+// Graphpolicies
+#include <graybat/graphPolicy/BGL.hpp>
+
+// Serializationpolicies
+#include <graybat/serializationPolicy/ByteCast.hpp>
+#include <graybat/serializationPolicy/Forward.hpp>
+
+// Communicationpolicies
+#ifdef graybat_ZMQ_CP_ENABLED
+  #include <graybat/communicationPolicy/ZMQ.hpp>
+#endif
+
+#ifdef graybat_BMPI_CP_ENABLED
+  #include <graybat/communicationPolicy/BMPI.hpp>
+#endif
+
+// Mappings
+#include <graybat/mapping/Consecutive.hpp>
+#include <graybat/mapping/Filter.hpp>
+#include <graybat/mapping/Random.hpp>
+#include <graybat/mapping/Roundrobin.hpp>
+
+// Pattern
+#include <graybat/pattern/BiStar.hpp>
+#include <graybat/pattern/Chain.hpp>
+#include <graybat/pattern/EdgeLess.hpp>
+#include <graybat/pattern/FullyConnected.hpp>
+#include <graybat/pattern/Grid.hpp>
+#include <graybat/pattern/GridDiagonal.hpp>
+#include <graybat/pattern/HyperCube.hpp>
+#include <graybat/pattern/InStar.hpp>
+#include <graybat/pattern/None.hpp>
+#include <graybat/pattern/OutStar.hpp>
+#include <graybat/pattern/Random.hpp>
+#include <graybat/pattern/Ring.hpp>
+

--- a/test/integration/CageTests.cpp
+++ b/test/integration/CageTests.cpp
@@ -20,274 +20,50 @@
 
 // STL
 #include <array>
-#include <vector>
-#include <iostream>   /* std::cout, std::endl */
+#include <cstdlib> /* std::getenv */
 #include <functional> /* std::plus, std::ref */
-#include <cstdlib>    /* std::getenv */
-#include <string>     /* std::string, std::stoi */
-#include <list>       /* std::list */
+#include <iostream> /* std::cout, std::endl */
+#include <list> /* std::list */
+#include <string> /* std::string, std::stoi */
+#include <vector>
 
 // BOOST
-#include <boost/test/unit_test.hpp>
+#include <boost/hana/concat.hpp>
+#include <boost/hana/for_each.hpp>
 #include <boost/hana/tuple.hpp>
-#include <boost/hana/append.hpp>
+#include <boost/test/unit_test.hpp>
 
 // GRAYBAT
-#include <graybat/Cage.hpp>
-#include <graybat/communicationPolicy/BMPI.hpp>
-#include <graybat/communicationPolicy/ZMQ.hpp>
-#include <graybat/graphPolicy/BGL.hpp>
-#include <graybat/serializationPolicy/ByteCast.hpp>
-#include <graybat/serializationPolicy/Forward.hpp>
-#include <graybat/mapping/Random.hpp>
-#include <graybat/mapping/Consecutive.hpp>
-#include <graybat/mapping/Roundrobin.hpp>
-#include <graybat/pattern/FullyConnected.hpp>
-#include <graybat/pattern/InStar.hpp>
-#include <graybat/pattern/Grid.hpp>
+#include <graybat/graybat.hpp>
 
-/*******************************************************************************
- * Test Suites
- ******************************************************************************/
+// Test Utils
+#include "../utils.hpp"
 
-/***************************************************************************
- * Test Cases
- ****************************************************************************/
-BOOST_AUTO_TEST_SUITE(graybat_cage_tests)
-
-/*******************************************************************************
- * Communication Policies to Test
- ******************************************************************************/
 namespace hana = boost::hana;
 
+namespace {
 size_t const nRuns = 1;
-
-using ZMQ = graybat::communicationPolicy::ZMQ;
-using BMPI = graybat::communicationPolicy::BMPI;
-using GP = graybat::graphPolicy::BGL<>;
-using ZMQCage = graybat::Cage<ZMQ, GP>;
-using BMPICage = graybat::Cage<BMPI, GP>;
-using ZMQConfig = ZMQ::Config;
-using BMPIConfig = BMPI::Config;
-
-ZMQConfig zmqConfig = {
-    "localhost:5000", "tcp://127.0.0.1:5001",
-    static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
-    "context_cage_test"};
-
-BMPIConfig bmpiConfig;
-
-ZMQCage zmqCage(zmqConfig);
-BMPICage bmpiCage(bmpiConfig);
-
-auto cages = hana::make_tuple(std::ref(zmqCage), std::ref(bmpiCage));
-
-BOOST_AUTO_TEST_CASE(move_construct) {
-  hana::for_each(cages, [](auto cageRef) {
-    // Test run
-    {
-      auto &cage = cageRef.get();
-      auto cage2 = std::move(cage);
-      cage = std::move(cage2);
-    }
-  });
+auto cages = graybat::test::utils::getCages();
 }
 
-BOOST_AUTO_TEST_CASE(send_recv) {
-  hana::for_each(cages, [](auto cageRef) {
-    // Test setup
-    using Cage = typename decltype(cageRef)::type;
-    using GP = typename Cage::GraphPolicy;
-    using Event = typename Cage::Event;
-    using Vertex = typename Cage::Vertex;
-    using Edge = typename Cage::Edge;
+BOOST_AUTO_TEST_SUITE(graybat_cage_tests)
 
-    // Test run
-    {
-      const unsigned nElements = 1000;
-
-      auto &cage = cageRef.get();
-      cage.setGraph(
-          graybat::pattern::FullyConnected<GP>(cage.getPeers().size()));
-      cage.distribute(graybat::mapping::Roundrobin());
-
-      for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
-        std::vector<Event> events;
-        std::vector<unsigned> send(nElements, 0);
-        std::vector<unsigned> recv(nElements, 0);
-
-        for (unsigned i = 0; i < send.size(); ++i) {
-          send.at(i) = i;
-        }
-
-        // Send state to neighbor cells
-        for (Vertex &v : cage.getHostedVertices()) {
-          for (Edge edge : cage.getOutEdges(v)) {
-            cage.send(edge, send, events);
-          }
-        }
-
-        // Recv state from neighbor cells
-        for (Vertex &v : cage.getHostedVertices()) {
-          for (Edge edge : cage.getInEdges(v)) {
-            cage.recv(edge, recv);
-            for (unsigned i = 0; i < recv.size(); ++i) {
-              BOOST_CHECK_EQUAL(recv.at(i), i);
-            }
-          }
-        }
-
-        for (Event &e : events) {
-          e.wait();
-        }
-      }
-    }
-
-  });
-}
-
-BOOST_AUTO_TEST_CASE(asyncSend_recv) {
-  hana::for_each(cages, [](auto cageRef) {
-    // Test setup
-    using Cage = typename decltype(cageRef)::type;
-    using GP = typename Cage::GraphPolicy;
-    using Event = typename Cage::Event;
-    using Vertex = typename Cage::Vertex;
-    using Edge = typename Cage::Edge;
-
-    // Test run
-    {
-
-      auto &cage = cageRef.get();
-
-      cage.setGraph(
-          graybat::pattern::FullyConnected<GP>(cage.getPeers().size()));
-      cage.distribute(graybat::mapping::Consecutive());
-
-      const unsigned nElements = 1000;
-
-      for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
-        std::vector<Event> events;
-        std::vector<unsigned> send(nElements, 0);
-        std::vector<unsigned> recv(nElements, 0);
-
-        for (unsigned i = 0; i < send.size(); ++i) {
-          send.at(i) = i;
-        }
-
-        // Send state to neighbor cells
-        for (Vertex &v : cage.getHostedVertices()) {
-          for (Edge edge : cage.getOutEdges(v)) {
-            cage.send(edge, send, events);
-          }
-        }
-
-        // Recv state from neighbor cells
-        for (Vertex &v : cage.getHostedVertices()) {
-          for (Edge edge : cage.getInEdges(v)) {
-            cage.recv(edge, recv);
-            for (unsigned i = 0; i < recv.size(); ++i) {
-              BOOST_CHECK_EQUAL(recv.at(i), i);
-            }
-          }
-        }
-
-        // Wait to finish events
-        for (unsigned i = 0; i < events.size(); ++i) {
-          events.back().wait();
-          events.pop_back();
-        }
-      }
-    }
-
-  });
-}
-
-BOOST_AUTO_TEST_CASE(shouldAsyncSendAndAsyncRecv) {
-  hana::for_each(cages, [](auto cageRef) {
-    // Test setup
-    using Cage = typename decltype(cageRef)::type;
-    using GP = typename Cage::GraphPolicy;
-    using Event = typename Cage::Event;
-    using Vertex = typename Cage::Vertex;
-    using Edge = typename Cage::Edge;
-
-    // Test run
-    {
-
-      auto &cage = cageRef.get();
-
-      cage.setGraph(
-          graybat::pattern::FullyConnected<GP>(cage.getPeers().size()));
-      cage.distribute(graybat::mapping::Consecutive());
-
-      const unsigned nElements = 10;
-
-      for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
-        std::vector<Event> sendEvents;
-        std::vector<Event> recvEvents;
-        std::vector<unsigned> send(nElements, 0);
-        std::list<std::vector<unsigned>> recv(0);
-
-        for (unsigned i = 0; i < send.size(); ++i) {
-          send.at(i) = i;
-        }
-
-        // Send state to neighbor cells
-        for (Vertex &v : cage.getHostedVertices()) {
-          for (Edge edge : cage.getOutEdges(v)) {
-            cage.send(edge, send, sendEvents);
-          }
-        }
-
-        // Recv state from neighbor cells
-        for (Vertex &v : cage.getHostedVertices()) {
-          for (Edge edge : cage.getInEdges(v)) {
-            recv.push_back(std::vector<unsigned>(nElements, 0));
-            cage.recv(edge, recv.back(), recvEvents);
-          }
-        }
-
-        // Wait to finish send events
-        for (unsigned i = 0; i < sendEvents.size(); ++i) {
-          sendEvents.back().wait();
-          sendEvents.pop_back();
-        }
-
-        // Wait to finish recv events
-        while (true) {
-          if (recvEvents.empty())
-            break;
-          for (auto it = recvEvents.begin(); it != recvEvents.end();) {
-            if (it->ready()) {
-              it = recvEvents.erase(it);
-            } else {
-              it++;
-            }
-          }
-        }
-
-        for (unsigned i = 0; i < recvEvents.size(); ++i) {
-          recvEvents.back().wait();
-          recvEvents.pop_back();
-        }
-
-        // Check values of async received data
-        for (auto v : recv) {
-          for (unsigned i = 0; i < v.size(); ++i) {
-            BOOST_CHECK_EQUAL(v.at(i), i);
-          }
-        }
-      }
-    }
-  });
-}
-
-BOOST_AUTO_TEST_CASE(shouldAsyncReceiveWithFuture)
+BOOST_AUTO_TEST_CASE(move_construct)
 {
-    hana::for_each(cages, [](auto cageRef) {
+    hana::for_each(cages, [](auto cage) {
+        // Test run
+        {
+            auto cage2 = std::move(cage);
+            cage = std::move(cage2);
+        }
+    });
+}
+
+BOOST_AUTO_TEST_CASE(send_recv)
+{
+    hana::for_each(cages, [](auto cage) {
         // Test setup
-        using Cage = typename decltype(cageRef)::type;
+        using Cage = typename decltype(cage)::element_type;
         using GP = typename Cage::GraphPolicy;
         using Event = typename Cage::Event;
         using Vertex = typename Cage::Vertex;
@@ -295,11 +71,191 @@ BOOST_AUTO_TEST_CASE(shouldAsyncReceiveWithFuture)
 
         // Test run
         {
+            const unsigned nElements = 1000;
 
-            auto& cage = cageRef.get();
+            cage->setGraph(graybat::pattern::FullyConnected<GP>(cage->getPeers().size()));
+            cage->distribute(graybat::mapping::Roundrobin());
 
-            cage.setGraph(graybat::pattern::FullyConnected<GP>(cage.getPeers().size()));
-            cage.distribute(graybat::mapping::Consecutive());
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
+                std::vector<Event> events;
+                std::vector<unsigned> send(nElements, 0);
+                std::vector<unsigned> recv(nElements, 0);
+
+                for (unsigned i = 0; i < send.size(); ++i) {
+                    send.at(i) = i;
+                }
+
+                // Send state to neighbor cells
+                for (Vertex& v : cage->getHostedVertices()) {
+                    for (Edge edge : cage->getOutEdges(v)) {
+                        cage->send(edge, send, events);
+                    }
+                }
+
+                // Recv state from neighbor cells
+                for (Vertex& v : cage->getHostedVertices()) {
+                    for (Edge edge : cage->getInEdges(v)) {
+                        cage->recv(edge, recv);
+                        for (unsigned i = 0; i < recv.size(); ++i) {
+                            BOOST_CHECK_EQUAL(recv.at(i), i);
+                        }
+                    }
+                }
+
+                for (Event& e : events) {
+                    e.wait();
+                }
+            }
+        }
+
+    });
+}
+
+BOOST_AUTO_TEST_CASE(asyncSend_recv)
+{
+    hana::for_each(cages, [](auto cage) {
+        // Test setup
+        using Cage = typename decltype(cage)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Event = typename Cage::Event;
+        using Vertex = typename Cage::Vertex;
+        using Edge = typename Cage::Edge;
+
+        // Test run
+        {
+            cage->setGraph(graybat::pattern::FullyConnected<GP>(cage->getPeers().size()));
+            cage->distribute(graybat::mapping::Consecutive());
+
+            const unsigned nElements = 1000;
+
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
+                std::vector<Event> events;
+                std::vector<unsigned> send(nElements, 0);
+                std::vector<unsigned> recv(nElements, 0);
+
+                for (unsigned i = 0; i < send.size(); ++i) {
+                    send.at(i) = i;
+                }
+
+                // Send state to neighbor cells
+                for (Vertex& v : cage->getHostedVertices()) {
+                    for (Edge edge : cage->getOutEdges(v)) {
+                        cage->send(edge, send, events);
+                    }
+                }
+
+                // Recv state from neighbor cells
+                for (Vertex& v : cage->getHostedVertices()) {
+                    for (Edge edge : cage->getInEdges(v)) {
+                        cage->recv(edge, recv);
+                        for (unsigned i = 0; i < recv.size(); ++i) {
+                            BOOST_CHECK_EQUAL(recv.at(i), i);
+                        }
+                    }
+                }
+
+                // Wait to finish events
+                for (unsigned i = 0; i < events.size(); ++i) {
+                    events.back().wait();
+                    events.pop_back();
+                }
+            }
+        }
+
+    });
+}
+
+BOOST_AUTO_TEST_CASE(shouldAsyncSendAndAsyncRecv)
+{
+    hana::for_each(cages, [](auto cage) {
+        // Test setup
+        using Cage = typename decltype(cage)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Event = typename Cage::Event;
+        using Vertex = typename Cage::Vertex;
+        using Edge = typename Cage::Edge;
+
+        // Test run
+        {
+            cage->setGraph(graybat::pattern::FullyConnected<GP>(cage->getPeers().size()));
+            cage->distribute(graybat::mapping::Consecutive());
+
+            const unsigned nElements = 10;
+
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
+                std::vector<Event> sendEvents;
+                std::vector<Event> recvEvents;
+                std::vector<unsigned> send(nElements, 0);
+                std::list<std::vector<unsigned>> recv(0);
+
+                for (unsigned i = 0; i < send.size(); ++i) {
+                    send.at(i) = i;
+                }
+
+                // Send state to neighbor cells
+                for (Vertex& v : cage->getHostedVertices()) {
+                    for (Edge edge : cage->getOutEdges(v)) {
+                        cage->send(edge, send, sendEvents);
+                    }
+                }
+
+                // Recv state from neighbor cells
+                for (Vertex& v : cage->getHostedVertices()) {
+                    for (Edge edge : cage->getInEdges(v)) {
+                        recv.push_back(std::vector<unsigned>(nElements, 0));
+                        cage->recv(edge, recv.back(), recvEvents);
+                    }
+                }
+
+                // Wait to finish send events
+                for (unsigned i = 0; i < sendEvents.size(); ++i) {
+                    sendEvents.back().wait();
+                    sendEvents.pop_back();
+                }
+
+                // Wait to finish recv events
+                while (true) {
+                    if (recvEvents.empty())
+                        break;
+                    for (auto it = recvEvents.begin(); it != recvEvents.end();) {
+                        if (it->ready()) {
+                            it = recvEvents.erase(it);
+                        } else {
+                            it++;
+                        }
+                    }
+                }
+
+                for (unsigned i = 0; i < recvEvents.size(); ++i) {
+                    recvEvents.back().wait();
+                    recvEvents.pop_back();
+                }
+
+                // Check values of async received data
+                for (auto v : recv) {
+                    for (unsigned i = 0; i < v.size(); ++i) {
+                        BOOST_CHECK_EQUAL(v.at(i), i);
+                    }
+                }
+            }
+        }
+    });
+}
+
+BOOST_AUTO_TEST_CASE(shouldAsyncReceiveWithFuture)
+{
+    hana::for_each(cages, [](auto cage) {
+        // Test setup
+        using Cage = typename decltype(cage)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Event = typename Cage::Event;
+        using Vertex = typename Cage::Vertex;
+        using Edge = typename Cage::Edge;
+
+        // Test run
+        {
+            cage->setGraph(graybat::pattern::FullyConnected<GP>(cage->getPeers().size()));
+            cage->distribute(graybat::mapping::Consecutive());
 
             const unsigned nElements = 1000000;
 
@@ -314,17 +270,17 @@ BOOST_AUTO_TEST_CASE(shouldAsyncReceiveWithFuture)
             }
 
             // Send state to neighbor cells
-            for (Vertex& v : cage.getHostedVertices()) {
-                for (Edge edge : cage.getOutEdges(v)) {
-                    cage.send(edge, send, sendEvents);
+            for (Vertex& v : cage->getHostedVertices()) {
+                for (Edge edge : cage->getOutEdges(v)) {
+                    cage->send(edge, send, sendEvents);
                 }
             }
 
             // Recv state from neighbor cells
-            for (Vertex& v : cage.getHostedVertices()) {
-                for (Edge edge : cage.getInEdges(v)) {
+            for (Vertex& v : cage->getHostedVertices()) {
+                for (Edge edge : cage->getInEdges(v)) {
                     recv.push_back(std::vector<unsigned>(nElements, 0));
-                    recvFutures.emplace_back(cage.asyncRecv(edge, recv.back()));
+                    recvFutures.emplace_back(cage->asyncRecv(edge, recv.back()));
                 }
             }
 
@@ -344,185 +300,173 @@ BOOST_AUTO_TEST_CASE(shouldAsyncReceiveWithFuture)
 
 BOOST_AUTO_TEST_CASE(reduce)
 {
-    hana::for_each(cages, [](auto cageRef) {
+    hana::for_each(cages, [](auto cage) {
         // Test setup
-        using Cage = typename decltype(cageRef)::type;
+        using Cage = typename decltype(cage)::element_type;
         using GP = typename Cage::GraphPolicy;
         using Vertex = typename Cage::Vertex;
 
         // Test run
         {
-
-            auto& cage = cageRef.get();
-
-            cage.setGraph(graybat::pattern::Grid<GP>(3, 3));
-            cage.distribute(graybat::mapping::Consecutive());
+            cage->setGraph(graybat::pattern::Grid<GP>(3, 3));
+            cage->distribute(graybat::mapping::Consecutive());
 
             const unsigned nElements = 10;
 
             std::vector<unsigned> send(nElements, 1);
             std::vector<unsigned> recv(nElements, 0);
 
-            Vertex rootVertex = cage.getVertex(0);
+            Vertex rootVertex = cage->getVertex(0);
 
-            for (Vertex v : cage.getHostedVertices()) {
-                cage.reduce(rootVertex, v, std::plus<unsigned>(), send, recv);
+            for (Vertex v : cage->getHostedVertices()) {
+                cage->reduce(rootVertex, v, std::plus<unsigned>(), send, recv);
             }
 
-            if (cage.isHosting(rootVertex)) {
+            if (cage->isHosting(rootVertex)) {
                 for (unsigned receivedElement : recv) {
-                    BOOST_CHECK_EQUAL(receivedElement, cage.getVertices().size());
+                    BOOST_CHECK_EQUAL(receivedElement, cage->getVertices().size());
                 }
             }
         }
     });
 }
 
-BOOST_AUTO_TEST_CASE(allReduce) {
-  hana::for_each(cages, [](auto cageRef) {
-    // Test setup
-    using Cage = typename decltype(cageRef)::type;
-    using GP = typename Cage::GraphPolicy;
-    using Vertex = typename Cage::Vertex;
+BOOST_AUTO_TEST_CASE(allReduce)
+{
+    hana::for_each(cages, [](auto cage) {
+        // Test setup
+        using Cage = typename decltype(cage)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Vertex = typename Cage::Vertex;
 
-    // Test run
-    {
+        // Test run
+        {
+            cage->setGraph(
+                graybat::pattern::Grid<GP>(cage->getPeers().size(), cage->getPeers().size()));
+            cage->distribute(graybat::mapping::Consecutive());
 
-      auto &cage = cageRef.get();
+            const unsigned nElements = 10;
 
-      cage.setGraph(graybat::pattern::Grid<GP>(cage.getPeers().size(),
-                                               cage.getPeers().size()));
-      cage.distribute(graybat::mapping::Consecutive());
+            std::vector<unsigned> send(nElements, 1);
+            std::vector<unsigned> recv(nElements, 0);
 
-      const unsigned nElements = 10;
+            for (Vertex v : cage->getHostedVertices()) {
+                cage->allReduce(v, std::plus<unsigned>(), send, recv);
+            }
 
-      std::vector<unsigned> send(nElements, 1);
-      std::vector<unsigned> recv(nElements, 0);
-
-      for (Vertex v : cage.getHostedVertices()) {
-        cage.allReduce(v, std::plus<unsigned>(), send, recv);
-      }
-
-      for (unsigned receivedElement : recv) {
-        BOOST_CHECK_EQUAL(receivedElement, cage.getVertices().size());
-      }
-    }
-
-  });
-}
-
-BOOST_AUTO_TEST_CASE(gather) {
-  hana::for_each(cages, [](auto cageRef) {
-    // Test setup
-    using Cage = typename decltype(cageRef)::type;
-    using GP = typename Cage::GraphPolicy;
-    using Vertex = typename Cage::Vertex;
-
-
-    // Test run
-    {
-      auto &cage = cageRef.get();
-
-      cage.setGraph(graybat::pattern::Grid<GP>(3, 3));
-      cage.distribute(graybat::mapping::Consecutive());
-
-      const unsigned nElements = 10;
-      const unsigned testValue = 1;
-      const bool reorder = true;
-
-      std::vector<unsigned> send(nElements, testValue);
-      std::vector<unsigned> recv(nElements * cage.getVertices().size(), 0);
-
-      Vertex rootVertex = cage.getVertex(0);
-
-      for (Vertex v : cage.getHostedVertices()) {
-        cage.gather(rootVertex, v, send, recv, reorder);
-      }
-
-      if (cage.isHosting(rootVertex)) {
-        for (unsigned receivedElement : recv) {
-          BOOST_CHECK_EQUAL(receivedElement, testValue);
+            for (unsigned receivedElement : recv) {
+                BOOST_CHECK_EQUAL(receivedElement, cage->getVertices().size());
+            }
         }
-      }
-    }
-  });
+
+    });
 }
 
+BOOST_AUTO_TEST_CASE(gather)
+{
+    hana::for_each(cages, [](auto cage) {
+        // Test setup
+        using Cage = typename decltype(cage)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Vertex = typename Cage::Vertex;
 
-BOOST_AUTO_TEST_CASE(allGather) {
-  hana::for_each(cages, [](auto cageRef) {
-    // Test setup
-    using Cage = typename decltype(cageRef)::type;
-    using GP = typename Cage::GraphPolicy;
-    using Vertex = typename Cage::Vertex;
+        // Test run
+        {
+            cage->setGraph(graybat::pattern::Grid<GP>(3, 3));
+            cage->distribute(graybat::mapping::Consecutive());
 
-    // Test run
-    {
+            const unsigned nElements = 10;
+            const unsigned testValue = 1;
+            const bool reorder = true;
 
-      auto &cage = cageRef.get();
+            std::vector<unsigned> send(nElements, testValue);
+            std::vector<unsigned> recv(nElements * cage->getVertices().size(), 0);
 
-      cage.setGraph(graybat::pattern::Grid<GP>(cage.getPeers().size(),
-                                               cage.getPeers().size()));
-      cage.distribute(graybat::mapping::Consecutive());
+            Vertex rootVertex = cage->getVertex(0);
 
-      const unsigned nElements = 10;
-      const unsigned testValue = 1;
-      const bool reorder = true;
+            for (Vertex v : cage->getHostedVertices()) {
+                cage->gather(rootVertex, v, send, recv, reorder);
+            }
 
-      std::vector<unsigned> send(nElements, testValue);
-      std::vector<unsigned> recv(nElements * cage.getVertices().size(), 0);
-
-      for (Vertex v : cage.getHostedVertices()) {
-        cage.allGather(v, send, recv, reorder);
-      }
-
-      for (unsigned receivedElement : recv) {
-        BOOST_CHECK_EQUAL(receivedElement, testValue);
-      }
-    }
-  });
-}
-
-BOOST_AUTO_TEST_CASE(spreadAndCollect) {
-  hana::for_each(cages, [](auto cageRef) {
-    // Test setup
-    using Cage = typename decltype(cageRef)::type;
-    using GP = typename Cage::GraphPolicy;
-    using Event = typename Cage::Event;
-    using Vertex = typename Cage::Vertex;
-
-    // Test run
-    {
-
-      auto &cage = cageRef.get();
-
-      cage.setGraph(graybat::pattern::InStar<GP>(cage.getPeers().size()));
-      cage.distribute(graybat::mapping::Consecutive());
-
-      const unsigned nElements = 10;
-      const unsigned testValue = 1;
-      std::vector<Event> events;
-
-      std::vector<unsigned> send(nElements, testValue);
-
-      for (Vertex v : cage.getHostedVertices()) {
-        v.spread(send, events);
-      }
-
-      for (Vertex v : cage.getHostedVertices()) {
-        std::vector<unsigned> recv(v.nInEdges() * nElements, 0);
-        v.collect(recv);
-        for (unsigned receivedElement : recv) {
-          BOOST_CHECK_EQUAL(receivedElement, testValue);
+            if (cage->isHosting(rootVertex)) {
+                for (unsigned receivedElement : recv) {
+                    BOOST_CHECK_EQUAL(receivedElement, testValue);
+                }
+            }
         }
-      }
+    });
+}
 
-      for (unsigned i = 0; i < events.size(); ++i) {
-        events.back().wait();
-        events.pop_back();
-      }
-    }
-  });
+BOOST_AUTO_TEST_CASE(allGather)
+{
+    hana::for_each(cages, [](auto cage) {
+        // Test setup
+        using Cage = typename decltype(cage)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Vertex = typename Cage::Vertex;
+
+        // Test run
+        {
+            cage->setGraph(
+                graybat::pattern::Grid<GP>(cage->getPeers().size(), cage->getPeers().size()));
+            cage->distribute(graybat::mapping::Consecutive());
+
+            const unsigned nElements = 10;
+            const unsigned testValue = 1;
+            const bool reorder = true;
+
+            std::vector<unsigned> send(nElements, testValue);
+            std::vector<unsigned> recv(nElements * cage->getVertices().size(), 0);
+
+            for (Vertex v : cage->getHostedVertices()) {
+                cage->allGather(v, send, recv, reorder);
+            }
+
+            for (unsigned receivedElement : recv) {
+                BOOST_CHECK_EQUAL(receivedElement, testValue);
+            }
+        }
+    });
+}
+
+BOOST_AUTO_TEST_CASE(spreadAndCollect)
+{
+    hana::for_each(cages, [](auto cage) {
+        // Test setup
+        using Cage = typename decltype(cage)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Event = typename Cage::Event;
+        using Vertex = typename Cage::Vertex;
+
+        // Test run
+        {
+            cage->setGraph(graybat::pattern::InStar<GP>(cage->getPeers().size()));
+            cage->distribute(graybat::mapping::Consecutive());
+
+            const unsigned nElements = 10;
+            const unsigned testValue = 1;
+            std::vector<Event> events;
+
+            std::vector<unsigned> send(nElements, testValue);
+
+            for (Vertex v : cage->getHostedVertices()) {
+                v.spread(send, events);
+            }
+
+            for (Vertex v : cage->getHostedVertices()) {
+                std::vector<unsigned> recv(v.nInEdges() * nElements, 0);
+                v.collect(recv);
+                for (unsigned receivedElement : recv) {
+                    BOOST_CHECK_EQUAL(receivedElement, testValue);
+                }
+            }
+
+            for (unsigned i = 0; i < events.size(); ++i) {
+                events.back().wait();
+                events.pop_back();
+            }
+        }
+    });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/integration/CommunicationPolicyTests.cpp
+++ b/test/integration/CommunicationPolicyTests.cpp
@@ -19,239 +19,189 @@
  */
 
 // BOOST
-#include <boost/test/unit_test.hpp>
+#include <boost/hana/concat.hpp>
+#include <boost/hana/for_each.hpp>
 #include <boost/hana/tuple.hpp>
+#include <boost/test/unit_test.hpp>
 
 // STL
-#include <iostream>   /* std::cout, std::endl */
+#include <iostream> /* std::cout, std::endl */
 
 // GRAYBAT
-#include <graybat/Cage.hpp>
-#include <graybat/communicationPolicy/ZMQ.hpp>
-#include <graybat/communicationPolicy/BMPI.hpp>
+#include <graybat/graybat.hpp>
 
-/*******************************************************************************
- * Communication Policies to Test
- ******************************************************************************/
+// Test Utils
+#include "../utils.hpp"
+
 namespace hana = boost::hana;
 
 namespace {
 size_t const nRuns = 1;
-
-using ZMQ = graybat::communicationPolicy::ZMQ;
-using BMPI = graybat::communicationPolicy::BMPI;
-using ZMQConfig = ZMQ::Config;
-using BMPIConfig = BMPI::Config;
-
-ZMQConfig zmqConfig = {
-    "localhost:5000", "tcp://127.0.0.1:5001",
-    static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
-    "context_cp_test"};
-
-BMPIConfig bmpiConfig;
-
-ZMQ zmqCP(zmqConfig);
-BMPI bmpiCP(bmpiConfig);
-
-auto communicationPolicies =
-    hana::make_tuple(std::ref(zmqCP), std::ref(bmpiCP));
+auto communicationPolicies = graybat::test::utils::getCommunicationPolicies();
 }
 
-/*******************************************************************************
- * Point to Point Test Suites
- ******************************************************************************/
-BOOST_AUTO_TEST_SUITE( graybat_cp_point_to_point )
+BOOST_AUTO_TEST_SUITE(graybat_cp_point_to_point)
 
-
-/***************************************************************************
- * Test Cases
- ****************************************************************************/
-BOOST_AUTO_TEST_CASE( construct ){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-            (void) cpRef;
-        });
-
+BOOST_AUTO_TEST_CASE(construct)
+{
+    hana::for_each(communicationPolicies, [](auto) {});
 }
 
-
-BOOST_AUTO_TEST_CASE( context ){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-	    // Test setup
-	    using CP      = typename decltype(cpRef)::type;
-	    using Context = typename CP::Context;	    
-	    CP& cp = cpRef.get();
-
-            // Test run
-            {
-              Context oldContext = cp.getGlobalContext();
-              for (unsigned i = 0; i < nRuns; ++i) {
-                // std::cout << "Run: " << i << std::endl;
-                Context newContext = cp.splitContext(true, oldContext);
-                oldContext = newContext;
-              }
-            }
-
-	});
-    
+BOOST_AUTO_TEST_CASE(context)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        auto oldContext = cp->getGlobalContext();
+        for (unsigned i = 0; i < nRuns; ++i) {
+            // std::cout << "Run: " << i << std::endl;
+            auto newContext = cp->splitContext(true, oldContext);
+            oldContext = newContext;
+        }
+    });
 }
 
+BOOST_AUTO_TEST_CASE(async_send_recv)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
 
-BOOST_AUTO_TEST_CASE( async_send_recv){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-	    // Test setup
-	    using CP      = typename decltype(cpRef)::type;
-	    using Context = typename CP::Context;
-            using Event = typename CP::Event;
-            CP &cp = cpRef.get();
+        // Test run
+        {
 
-            // Test run
-            {
+            const unsigned nElements = 10;
+            const unsigned tag = 99;
 
-              const unsigned nElements = 10;
-              const unsigned tag = 99;
+            auto context = cp->getGlobalContext();
 
-              Context context = cp.getGlobalContext();
-
-              for (unsigned i = 0; i < nRuns; ++i) {
+            for (unsigned i = 0; i < nRuns; ++i) {
                 std::vector<unsigned> recv(nElements, 0);
                 std::vector<Event> events;
 
                 for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
-                  std::vector<unsigned> data(nElements, 0);
-                  std::iota(data.begin(), data.end(), context.getVAddr());
-                  events.push_back(cp.asyncSend(vAddr, tag, context, data));
+                    std::vector<unsigned> data(nElements, 0);
+                    std::iota(data.begin(), data.end(), context.getVAddr());
+                    events.push_back(cp->asyncSend(vAddr, tag, context, data));
                 }
 
                 for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
-                  cp.recv(vAddr, tag, context, recv);
+                    cp->recv(vAddr, tag, context, recv);
 
-                  for (unsigned i = 0; i < recv.size(); ++i) {
-                    BOOST_CHECK_EQUAL(recv[i], vAddr + i);
-                  }
+                    for (unsigned i = 0; i < recv.size(); ++i) {
+                        BOOST_CHECK_EQUAL(recv[i], vAddr + i);
+                    }
                 }
 
-                for (Event &e : events) {
-                  e.wait();
+                for (Event& e : events) {
+                    e.wait();
                 }
-              }
-
+            }
         }
 
     });
+}
 
-    }
+BOOST_AUTO_TEST_CASE(async_send_async_recv)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
 
-    BOOST_AUTO_TEST_CASE( async_send_async_recv){
-        hana::for_each(communicationPolicies, [](auto cpRef){
-            // Test setup
-            using CP      = typename decltype(cpRef)::type;
-            using Context = typename CP::Context;
-            using Event   = typename CP::Event;
-            CP& cp = cpRef.get();
+        // Test run
+        {
 
-            // Test run
-            {
+            const unsigned nElements = 2;
+            const unsigned tag = 99;
 
-                const unsigned nElements = 2;
-                const unsigned tag = 99;
+            auto context = cp->getGlobalContext();
 
-                Context context = cp.getGlobalContext();
-
-                for(unsigned i = 0; i < nRuns; ++i){
-                    std::vector<unsigned> recv (nElements, 0);
-                    std::vector<Event> events;
-
-                    for(unsigned vAddr = 0; vAddr < context.size(); ++vAddr){
-                        std::vector<unsigned> data (nElements, 1);
-                        std::iota(data.begin(), data.end(), context.getVAddr());
-                        events.push_back(cp.asyncSend(vAddr, tag, context, data));
-                    }
-
-                    for(unsigned vAddr = 0; vAddr < context.size(); ++vAddr){
-                        Event e = cp.asyncRecv(vAddr, tag, context, recv);
-                        e.wait();
-                        for(unsigned i = 0; i < recv.size(); ++i){
-                            BOOST_CHECK_EQUAL(recv[i], vAddr+i);
-                        }
-                    }
-
-                    for(Event &e : events){
-                        e.wait();
-                    }
-                }
-
-            }
-
-        });
-
-    }
-
-
-
-
-    BOOST_AUTO_TEST_CASE( send_recv_all){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-	    // Test setup
-	    using CP      = typename decltype(cpRef)::type;
-	    using Context = typename CP::Context;
-            using Event = typename CP::Event;
-            CP &cp = cpRef.get();
-
-            // Test run
-            {
-
-              Context context = cp.getGlobalContext();
-
-              const unsigned nElements = 10;
-
-              for (unsigned i = 0; i < nRuns; ++i) {
+            for (unsigned i = 0; i < nRuns; ++i) {
                 std::vector<unsigned> recv(nElements, 0);
                 std::vector<Event> events;
 
                 for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
-                  std::vector<unsigned> data(nElements, 0);
-                  std::iota(data.begin(), data.end(), context.getVAddr());
-                  events.push_back(cp.asyncSend(vAddr, 99, context, data));
+                    std::vector<unsigned> data(nElements, 1);
+                    std::iota(data.begin(), data.end(), context.getVAddr());
+                    events.push_back(cp->asyncSend(vAddr, tag, context, data));
+                }
+
+                for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
+                    auto e = cp->asyncRecv(vAddr, tag, context, recv);
+                    e.wait();
+                    for (unsigned i = 0; i < recv.size(); ++i) {
+                        BOOST_CHECK_EQUAL(recv[i], vAddr + i);
+                    }
+                }
+
+                for (Event& e : events) {
+                    e.wait();
+                }
+            }
+        }
+
+    });
+}
+
+BOOST_AUTO_TEST_CASE(send_recv_all)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
+
+        // Test run
+        {
+
+            auto context = cp->getGlobalContext();
+
+            const unsigned nElements = 10;
+
+            for (unsigned i = 0; i < nRuns; ++i) {
+                std::vector<unsigned> recv(nElements, 0);
+                std::vector<Event> events;
+
+                for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
+                    std::vector<unsigned> data(nElements, 0);
+                    std::iota(data.begin(), data.end(), context.getVAddr());
+                    events.push_back(cp->asyncSend(vAddr, 99, context, data));
                 }
 
                 for (unsigned i = 0; i < context.size(); ++i) {
-                  Event e = cp.recv(context, recv);
+                    auto e = cp->recv(context, recv);
 
-                  unsigned vAddr = e.source();
+                    unsigned vAddr = e.source();
 
-                  for (unsigned i = 0; i < recv.size(); ++i) {
-                    BOOST_CHECK_EQUAL(recv[i], vAddr + i);
-                  }
+                    for (unsigned i = 0; i < recv.size(); ++i) {
+                        BOOST_CHECK_EQUAL(recv[i], vAddr + i);
+                    }
                 }
 
-                for (Event &e : events) {
-                  e.wait();
+                for (Event& e : events) {
+                    e.wait();
                 }
-              }
             }
-	    
-	});
+        }
 
+    });
 }
 
+BOOST_AUTO_TEST_CASE(send_recv_order)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
 
-BOOST_AUTO_TEST_CASE( send_recv_order ){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-	    // Test setup
-	    using CP      = typename decltype(cpRef)::type;
-	    using Context = typename CP::Context;
-	    using Event   = typename CP::Event;
-            CP &cp = cpRef.get();
+        // Test run
+        {
 
-            // Test run
-            {
+            auto context = cp->getGlobalContext();
 
-              Context context = cp.getGlobalContext();
+            const unsigned nElements = 10;
+            const unsigned tag = 99;
 
-              const unsigned nElements = 10;
-              const unsigned tag = 99;
-
-              for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
 
                 std::vector<Event> events;
 
@@ -264,419 +214,367 @@ BOOST_AUTO_TEST_CASE( send_recv_order ){
                 std::vector<unsigned> data3(nElements, context.getVAddr() + 2);
 
                 for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
-                  events.push_back(cp.asyncSend(vAddr, tag, context, data1));
-                  events.push_back(cp.asyncSend(vAddr, tag, context, data2));
-                  events.push_back(cp.asyncSend(vAddr, tag, context, data3));
+                    events.push_back(cp->asyncSend(vAddr, tag, context, data1));
+                    events.push_back(cp->asyncSend(vAddr, tag, context, data2));
+                    events.push_back(cp->asyncSend(vAddr, tag, context, data3));
                 }
 
                 for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
-                  cp.recv(vAddr, tag, context, recv1);
-                  cp.recv(vAddr, tag, context, recv2);
-                  cp.recv(vAddr, tag, context, recv3);
+                    cp->recv(vAddr, tag, context, recv1);
+                    cp->recv(vAddr, tag, context, recv2);
+                    cp->recv(vAddr, tag, context, recv3);
 
-                  for (unsigned i = 0; i < recv1.size(); ++i) {
-                    BOOST_CHECK_EQUAL(recv1[i], vAddr);
-                  }
+                    for (unsigned i = 0; i < recv1.size(); ++i) {
+                        BOOST_CHECK_EQUAL(recv1[i], vAddr);
+                    }
 
-                  for (unsigned i = 0; i < recv1.size(); ++i) {
-                    BOOST_CHECK_EQUAL(recv2[i], vAddr + 1);
-                  }
+                    for (unsigned i = 0; i < recv1.size(); ++i) {
+                        BOOST_CHECK_EQUAL(recv2[i], vAddr + 1);
+                    }
 
-                  for (unsigned i = 0; i < recv1.size(); ++i) {
-                    BOOST_CHECK_EQUAL(recv3[i], vAddr + 2);
-                  }
+                    for (unsigned i = 0; i < recv1.size(); ++i) {
+                        BOOST_CHECK_EQUAL(recv3[i], vAddr + 2);
+                    }
                 }
 
-                for (Event &e : events) {
-                  e.wait();
+                for (Event& e : events) {
+                    e.wait();
                 }
-              }
             }
-	    
-	});
+        }
 
+    });
 }
 
-BOOST_AUTO_TEST_CASE(shouldReceiveCorrectStatus) {
-  hana::for_each(communicationPolicies, [](auto cpRef) {
-    // Test setup
-    using CP = typename decltype(cpRef)::type;
-    using Context = typename CP::Context;
-    using Event = typename CP::Event;
-    CP &cp = cpRef.get();
+BOOST_AUTO_TEST_CASE(shouldReceiveCorrectStatus)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
 
-    // Test run
-    {
+        // Test run
+        {
 
-      const unsigned nElements = 10;
-      const unsigned tag = 99;
+            const unsigned nElements = 10;
+            const unsigned tag = 99;
 
-      Context context = cp.getGlobalContext();
+            auto context = cp->getGlobalContext();
 
-      std::vector<unsigned> recv(nElements, 0);
-      std::vector<unsigned> data(nElements, 0);
-      std::vector<Event> events;
+            std::vector<unsigned> recv(nElements, 0);
+            std::vector<unsigned> data(nElements, 0);
+            std::vector<Event> events;
 
-      for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
-        std::iota(data.begin(), data.end(), context.getVAddr());
-        events.push_back(cp.asyncSend(vAddr, tag, context, data));
-      }
+            for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
+                std::iota(data.begin(), data.end(), context.getVAddr());
+                events.push_back(cp->asyncSend(vAddr, tag, context, data));
+            }
 
-      for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
-        auto status = cp.probe(vAddr, tag, context);
-        BOOST_CHECK_EQUAL(status.tag(), tag);
-        BOOST_CHECK_EQUAL(status.source(), vAddr);
-        BOOST_CHECK_EQUAL(status.template size<unsigned>(), nElements);
-      }
+            for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
+                auto status = cp->probe(vAddr, tag, context);
+                BOOST_CHECK_EQUAL(status.tag(), tag);
+                BOOST_CHECK_EQUAL(status.source(), vAddr);
+                BOOST_CHECK_EQUAL(status.template size<unsigned>(), nElements);
+            }
 
-      for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
-          cp.recv(vAddr, tag, context, data);
-      }
-    }
-  });
+            for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
+                cp->recv(vAddr, tag, context, data);
+            }
+        }
+    });
 }
 
 BOOST_AUTO_TEST_CASE(shouldReturnNegativeStatus)
 {
-    hana::for_each(communicationPolicies, [](auto cpRef) {
-        // Test setup
-        using CP = typename decltype(cpRef)::type;
-        using Context = typename CP::Context;
-        CP& cp = cpRef.get();
+    hana::for_each(communicationPolicies, [](auto cp) {
+        const unsigned tag = 99;
+        auto context = cp->getGlobalContext();
 
-        // Test run
-        {
-            const unsigned tag = 99;
-            Context context = cp.getGlobalContext();
-
-            for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
-                auto status = cp.asyncProbe(vAddr, tag, context);
-                BOOST_REQUIRE(!status);
-            }
+        for (unsigned vAddr = 0; vAddr < context.size(); ++vAddr) {
+            auto status = cp->asyncProbe(vAddr, tag, context);
+            BOOST_REQUIRE(!status);
         }
     });
 }
 
 BOOST_AUTO_TEST_SUITE_END()
 
-
 /*******************************************************************************
  * Collective Test Suites
  ******************************************************************************/
-BOOST_AUTO_TEST_SUITE( graybat_cp_collectives )
-
+BOOST_AUTO_TEST_SUITE(graybat_cp_collectives)
 
 /*******************************************************************************
  * Test Cases
  ******************************************************************************/
-BOOST_AUTO_TEST_CASE( gather ){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-	    // Test setup
-	    using CP      = typename decltype(cpRef)::type;
-	    using Context = typename CP::Context;
-	    using Event   = typename CP::Event;
-            CP &cp = cpRef.get();
+BOOST_AUTO_TEST_CASE(gather)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
 
-            // Test run
-            {
-    
-                Context context = cp.getGlobalContext();
+        // Test run
+        {
 
-                const unsigned nElements = 10;
-                unsigned value = 9;
+            auto context = cp->getGlobalContext();
 
-                for(unsigned run_i = 0; run_i < nRuns; ++run_i){
-    
-                    std::vector<Event> events;
+            const unsigned nElements = 10;
+            unsigned value = 9;
 
-                    std::vector<unsigned> send (nElements, value);
-                    std::vector<unsigned> recv (nElements * context.size(), 0);
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
 
-                    cp.gather(0, context, send, recv);
+                std::vector<Event> events;
 
-                    if(context.getVAddr() == 0){
-                        for(auto d : recv){
-                            BOOST_CHECK_EQUAL(d, value);
-                        }
+                std::vector<unsigned> send(nElements, value);
+                std::vector<unsigned> recv(nElements * context.size(), 0);
 
-                    }
+                cp->gather(0, context, send, recv);
 
-                    for(Event &e : events){
-                        e.wait();
-	    
-                    }
-
-                }
-		
-            }
-	    
-        });
-
-}
-
-BOOST_AUTO_TEST_CASE( gather_var ){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-	    // Test setup
-	    using CP      = typename decltype(cpRef)::type;
-	    using Context = typename CP::Context;
-	    using Event   = typename CP::Event;
-            using VAddr = typename CP::VAddr;
-            CP &cp = cpRef.get();
-
-            // Test run
-            {
-    
-                Context context = cp.getGlobalContext();
-                std::vector<unsigned> recvCount;
-                
-                for(unsigned run_i = 0; run_i < nRuns; ++run_i){
-    
-                    std::vector<Event> events;
-
-                    std::vector<unsigned> send (context.getVAddr() + 1, context.getVAddr());
-                    std::vector<unsigned> recv;
-
-                    cp.gatherVar(0, context, send, recv, recvCount);
-
-                    if(context.getVAddr() == 0){
-                        unsigned i = 0;
-                        for(VAddr vAddr = 0; vAddr < context.size(); ++vAddr){
-                            for(unsigned j = 0; j < vAddr + 1; j++){
-                                BOOST_CHECK_EQUAL(recv.at(i), vAddr);
-                                i++;
-                            }
-                            
-                        }
-
-                    }
-
-                    for(Event &e : events){
-                        e.wait();
-	    
-                    }
-
-                }
-		
-            }
-	    
-        });
-
-}
-
-BOOST_AUTO_TEST_CASE( all_gather ){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-	    // Test setup
-	    using CP      = typename decltype(cpRef)::type;
-	    using Context = typename CP::Context;
-	    using Event   = typename CP::Event;
-            CP &cp = cpRef.get();
-            // Test run
-            {
-    
-                Context context = cp.getGlobalContext();
-
-                const unsigned nElements = 10;
-                unsigned value = 9;
-
-                for(unsigned run_i = 0; run_i < nRuns; ++run_i){
-    
-                    std::vector<Event> events;
-
-                    std::vector<unsigned> send (nElements, value);
-                    std::vector<unsigned> recv (nElements * context.size(), 0);
-
-                    cp.allGather(context, send, recv);
-
-                    for(auto d : recv){
+                if (context.getVAddr() == 0) {
+                    for (auto d : recv) {
                         BOOST_CHECK_EQUAL(d, value);
                     }
-
-
-                    for(Event &e : events){
-                        e.wait();
-	    
-                    }
-
                 }
-		
-            }
-	    
-        });
 
+                for (Event& e : events) {
+                    e.wait();
+                }
+            }
+        }
+
+    });
 }
 
-BOOST_AUTO_TEST_CASE( all_gather_var ){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-	    // Test setup
-	    using CP      = typename decltype(cpRef)::type;
-	    using Context = typename CP::Context;
-	    using Event   = typename CP::Event;
-            using VAddr = typename CP::VAddr;
-            CP &cp = cpRef.get();
-            // Test run
-            {
-    
-                Context context = cp.getGlobalContext();
-                std::vector<unsigned> recvCount;
-                
-                for(unsigned run_i = 0; run_i < nRuns; ++run_i){
-    
-                    std::vector<Event> events;
+BOOST_AUTO_TEST_CASE(gather_var)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
+        using VAddr = typename CP::VAddr;
 
-                    std::vector<unsigned> send (context.getVAddr() + 1, context.getVAddr());
-                    std::vector<unsigned> recv;
+        // Test run
+        {
 
-                    cp.allGatherVar(context, send, recv, recvCount);
+            auto context = cp->getGlobalContext();
+            std::vector<unsigned> recvCount;
 
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
+
+                std::vector<Event> events;
+
+                std::vector<unsigned> send(context.getVAddr() + 1, context.getVAddr());
+                std::vector<unsigned> recv;
+
+                cp->gatherVar(0, context, send, recv, recvCount);
+
+                if (context.getVAddr() == 0) {
                     unsigned i = 0;
-                    for(VAddr vAddr = 0; vAddr < context.size(); ++vAddr){
-                        for(unsigned j = 0; j < vAddr + 1; j++){
+                    for (VAddr vAddr = 0; vAddr < context.size(); ++vAddr) {
+                        for (unsigned j = 0; j < vAddr + 1; j++) {
                             BOOST_CHECK_EQUAL(recv.at(i), vAddr);
                             i++;
                         }
-                            
                     }
-
-
-                    for(Event &e : events){
-                        e.wait();
-	    
-                    }
-
                 }
-		
-            }
-	    
-        });
 
+                for (Event& e : events) {
+                    e.wait();
+                }
+            }
+        }
+
+    });
 }
 
-BOOST_AUTO_TEST_CASE( scatter ){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-	    // Test setup
-	    using CP      = typename decltype(cpRef)::type;
-	    using Context = typename CP::Context;
-	    using Event   = typename CP::Event;
-            CP &cp = cpRef.get();
+BOOST_AUTO_TEST_CASE(all_gather)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
+        // Test run
+        {
 
-            // Test run
-            {
-    
-                Context context = cp.getGlobalContext();
+            auto context = cp->getGlobalContext();
 
-                const unsigned nElements = 10;
-                unsigned value = 9;
+            const unsigned nElements = 10;
+            unsigned value = 9;
 
-                for(unsigned run_i = 0; run_i < nRuns; ++run_i){
-    
-                    std::vector<Event> events;
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
 
-                    std::vector<unsigned> send (nElements * context.size(), value);
-                    std::vector<unsigned> recv (nElements, 0);
-                    
-                    cp.scatter(0, context, send, recv);
+                std::vector<Event> events;
 
-                    if(context.getVAddr() == 0){
-                        for(auto d : recv){
-                            BOOST_CHECK_EQUAL(d, value);
-                        }
+                std::vector<unsigned> send(nElements, value);
+                std::vector<unsigned> recv(nElements * context.size(), 0);
 
-                    }
+                cp->allGather(context, send, recv);
 
-                    for(Event &e : events){
-                        e.wait();
-	    
-                    }
-
+                for (auto d : recv) {
+                    BOOST_CHECK_EQUAL(d, value);
                 }
-		
-            }
-	    
-        });
 
+                for (Event& e : events) {
+                    e.wait();
+                }
+            }
+        }
+
+    });
 }
 
-BOOST_AUTO_TEST_CASE( reduce ){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-	    // Test setup
-	    using CP      = typename decltype(cpRef)::type;
-	    using Context = typename CP::Context;
-	    using Event   = typename CP::Event;
-            CP &cp = cpRef.get();
+BOOST_AUTO_TEST_CASE(all_gather_var)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
+        using VAddr = typename CP::VAddr;
+        // Test run
+        {
 
-            // Test run
-            {
-    
-                Context context = cp.getGlobalContext();
+            auto context = cp->getGlobalContext();
+            std::vector<unsigned> recvCount;
 
-                const unsigned nElements = 10;
-                unsigned value = 9;
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
 
-                for(unsigned run_i = 0; run_i < nRuns; ++run_i){
-    
-                    std::vector<Event> events;
+                std::vector<Event> events;
 
-                    std::vector<unsigned> send (nElements, value);
-                    std::vector<unsigned> recv (nElements, 0);
-                    
-                    cp.reduce(0, context, std::plus<unsigned>(), send, recv);
+                std::vector<unsigned> send(context.getVAddr() + 1, context.getVAddr());
+                std::vector<unsigned> recv;
 
-                    if(context.getVAddr() == 0){
-                        for(auto d : recv){
-                            BOOST_CHECK_EQUAL(d, value * context.size());
-                        }
+                cp->allGatherVar(context, send, recv, recvCount);
 
+                unsigned i = 0;
+                for (VAddr vAddr = 0; vAddr < context.size(); ++vAddr) {
+                    for (unsigned j = 0; j < vAddr + 1; j++) {
+                        BOOST_CHECK_EQUAL(recv.at(i), vAddr);
+                        i++;
                     }
-
-                    for(Event &e : events){
-                        e.wait();
-	    
-                    }
-
                 }
-		
-            }
-	    
-        });
 
+                for (Event& e : events) {
+                    e.wait();
+                }
+            }
+        }
+
+    });
 }
 
-BOOST_AUTO_TEST_CASE( broadcast ){
-    hana::for_each(communicationPolicies, [](auto cpRef){
-	    // Test setup
-	    using CP      = typename decltype(cpRef)::type;
-	    using Context = typename CP::Context;
-            using Event = typename CP::Event;
-            CP &cp = cpRef.get();
+BOOST_AUTO_TEST_CASE(scatter)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
 
-            // Test run
-            {
+        // Test run
+        {
 
-              Context context = cp.getGlobalContext();
+            auto context = cp->getGlobalContext();
 
-              const unsigned nElements = 10;
-              unsigned value = 9;
+            const unsigned nElements = 10;
+            unsigned value = 9;
 
-              for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
+
+                std::vector<Event> events;
+
+                std::vector<unsigned> send(nElements * context.size(), value);
+                std::vector<unsigned> recv(nElements, 0);
+
+                cp->scatter(0, context, send, recv);
+
+                if (context.getVAddr() == 0) {
+                    for (auto d : recv) {
+                        BOOST_CHECK_EQUAL(d, value);
+                    }
+                }
+
+                for (Event& e : events) {
+                    e.wait();
+                }
+            }
+        }
+
+    });
+}
+
+BOOST_AUTO_TEST_CASE(reduce)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
+
+        // Test run
+        {
+
+            auto context = cp->getGlobalContext();
+
+            const unsigned nElements = 10;
+            unsigned value = 9;
+
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
+
+                std::vector<Event> events;
+
+                std::vector<unsigned> send(nElements, value);
+                std::vector<unsigned> recv(nElements, 0);
+
+                cp->reduce(0, context, std::plus<unsigned>(), send, recv);
+
+                if (context.getVAddr() == 0) {
+                    for (auto d : recv) {
+                        BOOST_CHECK_EQUAL(d, value * context.size());
+                    }
+                }
+
+                for (Event& e : events) {
+                    e.wait();
+                }
+            }
+        }
+
+    });
+}
+
+BOOST_AUTO_TEST_CASE(broadcast)
+{
+    hana::for_each(communicationPolicies, [](auto cp) {
+        // Test setup
+        using CP = typename decltype(cp)::element_type;
+        using Event = typename CP::Event;
+
+        // Test run
+        {
+
+            auto context = cp->getGlobalContext();
+
+            const unsigned nElements = 10;
+            unsigned value = 9;
+
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
 
                 std::vector<Event> events;
 
                 std::vector<unsigned> data(nElements, value);
 
-                cp.broadcast(0, context, data);
+                cp->broadcast(0, context, data);
 
                 for (auto d : data) {
-                  BOOST_CHECK_EQUAL(d, value);
+                    BOOST_CHECK_EQUAL(d, value);
                 }
 
-                for (Event &e : events) {
-                  e.wait();
+                for (Event& e : events) {
+                    e.wait();
                 }
             }
-            }
-	    
-        });
+        }
 
+    });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/integration/EdgeTests.cpp
+++ b/test/integration/EdgeTests.cpp
@@ -19,115 +19,87 @@
  */
 
 // BOOST
-#include <boost/test/unit_test.hpp>
+#include <boost/hana/concat.hpp>
+#include <boost/hana/for_each.hpp>
 #include <boost/hana/tuple.hpp>
+#include <boost/test/unit_test.hpp>
 
 // STL
-#include <vector>
 #include <functional> // std::plus
+#include <vector>
 
 // GRAYBAT
-#include <graybat/Cage.hpp>
-#include <graybat/communicationPolicy/BMPI.hpp>
-#include <graybat/communicationPolicy/ZMQ.hpp>
-#include <graybat/serializationPolicy/ByteCast.hpp>
-#include <graybat/graphPolicy/BGL.hpp>
-#include <graybat/mapping/Consecutive.hpp>
-#include <graybat/pattern/Grid.hpp>
-#include <graybat/pattern/Chain.hpp>
+#include <graybat/graybat.hpp>
+
+// Test Utils
+#include "../utils.hpp"
 
 /***************************************************************************
  * Test Suites
  ****************************************************************************/
-BOOST_AUTO_TEST_SUITE( edge )
-
-/*******************************************************************************
- * Communication Policies to Test
- ******************************************************************************/
 namespace hana = boost::hana;
 
-using ZMQ        = graybat::communicationPolicy::ZMQ;
-using BMPI       = graybat::communicationPolicy::BMPI;
-using Serialization = graybat::serializationPolicy::ByteCast;
-using GP         = graybat::graphPolicy::BGL<>;
-using ZMQCage    = graybat::Cage<ZMQ, GP, Serialization >;
-using BMPICage   = graybat::Cage<BMPI, GP, Serialization >;
-using ZMQConfig  = ZMQ::Config;
-using BMPIConfig = BMPI::Config;
+namespace {
+auto cages = graybat::test::utils::getCages();
+}
 
-ZMQConfig zmqConfig = {"localhost:5000",
-                       "tcp://127.0.0.1:5001",
-                       static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
-					   "context_edge_test"};
-
-BMPIConfig bmpiConfig;
-
-ZMQCage zmqCage(zmqConfig);
-BMPICage bmpiCage(bmpiConfig);
-
-auto cages = hana::make_tuple(std::ref(zmqCage),
-                              std::ref(bmpiCage) );
-
+BOOST_AUTO_TEST_SUITE(edge)
 
 /***************************************************************************
  * Test Cases
  ****************************************************************************/
 
-BOOST_AUTO_TEST_CASE( send_recv ){
-        hana::for_each(cages, [](auto cageRef){
-	    // Test setup
-            using Cage    = typename decltype(cageRef)::type;
-            using GP      = typename Cage::GraphPolicy;            
-	    using Event   = typename Cage::Event;
-	    using Vertex  = typename Cage::Vertex;
-	    using Edge    = typename Cage::Edge;
+BOOST_AUTO_TEST_CASE(send_recv)
+{
+    hana::for_each(cages, [](auto cageRef) {
+        // Test setup
+        using Cage = typename decltype(cageRef)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Event = typename Cage::Event;
+        using Vertex = typename Cage::Vertex;
+        using Edge = typename Cage::Edge;
 
-	    // Test run
-	    {	
-    
-		std::vector<Event> events;
-                auto& grid = cageRef.get();
- 
-		grid.setGraph(graybat::pattern::Grid<GP>(grid.getPeers().size(),
-                                                         grid.getPeers().size()));
-		
-		grid.distribute(graybat::mapping::Consecutive());
+        // Test run
+        {
 
-		const unsigned nElements = 10;
-		const unsigned testValue = 5;
-    
-		std::vector<unsigned> send(nElements, testValue);
-		std::vector<unsigned> recv(nElements, 0);
-    
-    
-		for(Vertex v : grid.getHostedVertices()){
-		    for(Edge edge : grid.getOutEdges(v)){
-			Event e = edge << send;
-			events.push_back(e);
-		    }
-        
-		}
+            std::vector<Event> events;
+            auto& grid = *cageRef;
 
-		for(Vertex v : grid.getHostedVertices()){
-		    for(Edge edge : grid.getInEdges(v)){
-			edge >> recv;
-			for(unsigned u : recv){
-			    BOOST_CHECK_EQUAL(u, testValue);
-			}
-		    }
-        
-		}
+            grid.setGraph(
+                graybat::pattern::Grid<GP>(grid.getPeers().size(), grid.getPeers().size()));
 
-		// Wait to finish events
-		for(unsigned i = 0; i < events.size(); ++i){
-		    events.back().wait();
-		    events.pop_back();
-		}
+            grid.distribute(graybat::mapping::Consecutive());
 
-	    }
-	    
-	});
-    
+            const unsigned nElements = 10;
+            const unsigned testValue = 5;
+
+            std::vector<unsigned> send(nElements, testValue);
+            std::vector<unsigned> recv(nElements, 0);
+
+            for (Vertex v : grid.getHostedVertices()) {
+                for (Edge edge : grid.getOutEdges(v)) {
+                    Event e = edge << send;
+                    events.push_back(e);
+                }
+            }
+
+            for (Vertex v : grid.getHostedVertices()) {
+                for (Edge edge : grid.getInEdges(v)) {
+                    edge >> recv;
+                    for (unsigned u : recv) {
+                        BOOST_CHECK_EQUAL(u, testValue);
+                    }
+                }
+            }
+
+            // Wait to finish events
+            for (unsigned i = 0; i < events.size(); ++i) {
+                events.back().wait();
+                events.pop_back();
+            }
+        }
+
+    });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/integration/SerializationPolicyTests.cpp
+++ b/test/integration/SerializationPolicyTests.cpp
@@ -20,131 +20,97 @@
 
 // STL
 #include <array>
-#include <vector>
-#include <iostream>   /* std::cout, std::endl */
+#include <cstdlib> /* std::getenv */
 #include <functional> /* std::plus, std::ref */
-#include <cstdlib>    /* std::getenv */
-#include <string>     /* std::string, std::stoi */
-#include <list>       /* std::list */
+#include <iostream> /* std::cout, std::endl */
+#include <list> /* std::list */
+#include <string> /* std::string, std::stoi */
+#include <vector>
 
 // BOOST
-#include <boost/test/unit_test.hpp>
+#include <boost/hana/concat.hpp>
+#include <boost/hana/for_each.hpp>
 #include <boost/hana/tuple.hpp>
-#include <boost/hana/append.hpp>
+#include <boost/test/unit_test.hpp>
 
 // GRAYBAT
-#include <graybat/Cage.hpp>
-#include <graybat/communicationPolicy/BMPI.hpp>
-#include <graybat/communicationPolicy/ZMQ.hpp>
-#include <graybat/graphPolicy/BGL.hpp>
-#include <graybat/serializationPolicy/ByteCast.hpp>
-#include <graybat/serializationPolicy/Forward.hpp>
-#include <graybat/mapping/Random.hpp>
-#include <graybat/mapping/Consecutive.hpp>
-#include <graybat/mapping/Roundrobin.hpp>
-#include <graybat/pattern/FullyConnected.hpp>
-#include <graybat/pattern/InStar.hpp>
-#include <graybat/pattern/Grid.hpp>
+#include <graybat/graybat.hpp>
 
-/*******************************************************************************
- * Test Suites
- ******************************************************************************/
+// Test Utils
+#include "../utils.hpp"
 
-/***************************************************************************
- * Test Cases
- ****************************************************************************/
+namespace hana = boost::hana;
+
+namespace {
+size_t const nRuns = 1;
+auto cages = graybat::test::utils::getCages();
+}
+
 BOOST_AUTO_TEST_SUITE(graybat_serialization_policy_tests)
 
-/*******************************************************************************
- * Communication Policies to Test
- ******************************************************************************/
-    namespace hana = boost::hana;
-    size_t const nRuns = 1;
+BOOST_AUTO_TEST_CASE(move_construct)
+{
+    hana::for_each(cages, [](auto cage) {
+        // Test run
+        {
+            auto cage2 = std::move(cage);
+            cage = std::move(cage2);
+        }
+    });
+}
 
-    using ZMQ = graybat::communicationPolicy::ZMQ;
-    using BMPI = graybat::communicationPolicy::BMPI;
-    using GP = graybat::graphPolicy::BGL<>;
-    using Serialization = graybat::serializationPolicy::ByteCast;
-    using ZMQCage = graybat::Cage<ZMQ, GP, Serialization>;
-    using BMPICage = graybat::Cage<BMPI, GP, Serialization>;
-    using ZMQConfig = ZMQ::Config;
-    using BMPIConfig = BMPI::Config;
+BOOST_AUTO_TEST_CASE(shouldSendCustomType)
+{
+    hana::for_each(cages, [](auto cageRef) {
+        // Test setup
+        using Cage = typename decltype(cageRef)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Event = typename Cage::Event;
+        using Vertex = typename Cage::Vertex;
+        using Edge = typename Cage::Edge;
 
-    ZMQConfig zmqConfig = {
-        "localhost:5000", "tcp://127.0.0.1:5001",
-        static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
-        "context_serialization_test"};
+        struct CustomType {
+            uint8_t a;
+            uint8_t b;
+            std::array<uint64_t, 4096> c;
+            uint64_t d;
+        };
 
-    BMPIConfig bmpiConfig;
+        CustomType ct;
+        ct.a = 1;
+        ct.b = 2;
+        ct.d = 3;
 
-    ZMQCage zmqCage(zmqConfig);
-    BMPICage bmpiCage(bmpiConfig);
+        // Test run
+        {
+            auto& cage = *cageRef;
+            cage.setGraph(graybat::pattern::FullyConnected<GP>(cage.getPeers().size()));
+            cage.distribute(graybat::mapping::Roundrobin());
 
-    auto cages = hana::make_tuple(std::ref(zmqCage), std::ref(bmpiCage));
+            std::vector<Event> events;
+            std::vector<CustomType> send(1, ct);
+            std::vector<CustomType> recv(1);
 
-    BOOST_AUTO_TEST_CASE(move_construct) {
-        hana::for_each(cages, [](auto cageRef) {
-            // Test run
-            {
-                auto &cage = cageRef.get();
-                auto cage2 = std::move(cage);
-                cage = std::move(cage2);
-            }
-        });
-    }
-
-    BOOST_AUTO_TEST_CASE(shouldSendCustomType) {
-        hana::for_each(cages, [](auto cageRef) {
-            // Test setup
-            using Cage = typename decltype(cageRef)::type;
-            using GP = typename Cage::GraphPolicy;
-            using Event = typename Cage::Event;
-            using Vertex = typename Cage::Vertex;
-            using Edge = typename Cage::Edge;
-
-            struct CustomType {
-                uint8_t a;
-                uint8_t b;
-                std::array<uint64_t, 4096> c;
-                uint64_t d;
-            };
-
-            CustomType ct;
-            ct.a = 1;
-            ct.b = 2;
-            ct.d = 3;
-
-            // Test run
-            {
-                auto &cage = cageRef.get();
-                cage.setGraph(
-                    graybat::pattern::FullyConnected<GP>(cage.getPeers().size()));
-                cage.distribute(graybat::mapping::Roundrobin());
-
-                std::vector<Event> events;
-                std::vector<CustomType> send(1, ct);
-                std::vector<CustomType> recv(1);
-
-                for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
-                    // Send state to neighbor cells
-                    for (Vertex &v : cage.getHostedVertices()) {
-                        for (Edge edge : cage.getOutEdges(v)) {
-                            cage.send(edge, send, events);
-                        }
+            for (unsigned run_i = 0; run_i < nRuns; ++run_i) {
+                // Send state to neighbor cells
+                for (Vertex& v : cage.getHostedVertices()) {
+                    for (Edge edge : cage.getOutEdges(v)) {
+                        cage.send(edge, send, events);
                     }
+                }
 
-                    // Recv state from neighbor cells
-                    for (Vertex &v : cage.getHostedVertices()) {
-                        for (Edge edge : cage.getInEdges(v)) {
-                            cage.recv(edge, recv);
-                            BOOST_CHECK_EQUAL(recv.at(0).a, 1);
-                            BOOST_CHECK_EQUAL(recv.at(0).b, 2);
-                            BOOST_CHECK_EQUAL(recv.at(0).d, 3);
-                        }
+                // Recv state from neighbor cells
+                for (Vertex& v : cage.getHostedVertices()) {
+                    for (Edge edge : cage.getInEdges(v)) {
+                        cage.recv(edge, recv);
+                        BOOST_CHECK_EQUAL(recv.at(0).a, 1);
+                        BOOST_CHECK_EQUAL(recv.at(0).b, 2);
+                        BOOST_CHECK_EQUAL(recv.at(0).d, 3);
                     }
                 }
             }
+        }
 
-        });
-    }
+    });
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/integration/VertexTests.cpp
+++ b/test/integration/VertexTests.cpp
@@ -19,228 +19,183 @@
  */
 
 // BOOST
-#include <boost/test/unit_test.hpp>
+#include <boost/hana/concat.hpp>
+#include <boost/hana/for_each.hpp>
 #include <boost/hana/tuple.hpp>
+#include <boost/test/unit_test.hpp>
 
 // STL
-#include <vector>
 #include <functional> // std::plus
+#include <vector>
 
 // GRAYBAT
-#include <graybat/Cage.hpp>
-#include <graybat/communicationPolicy/BMPI.hpp>
-#include <graybat/communicationPolicy/ZMQ.hpp>
-#include <graybat/serializationPolicy/ByteCast.hpp>
-#include <graybat/graphPolicy/BGL.hpp>
-#include <graybat/mapping/Consecutive.hpp>
-#include <graybat/pattern/Grid.hpp>
-#include <graybat/pattern/Chain.hpp>
+#include <graybat/graybat.hpp>
 
-/*******************************************************************************
- * Test Suites
- *******************************************************************************/
-BOOST_AUTO_TEST_SUITE( vertex )
+// Test Utils
+#include "../utils.hpp"
 
-
-/*******************************************************************************
- * Communication Policies to Test
- ******************************************************************************/
 namespace hana = boost::hana;
 
-using ZMQ        = graybat::communicationPolicy::ZMQ;
-using BMPI       = graybat::communicationPolicy::BMPI;
-using GP         = graybat::graphPolicy::BGL<>;
-using Serialization = graybat::serializationPolicy::ByteCast;
-using ZMQCage    = graybat::Cage<ZMQ, GP, Serialization >;
-using BMPICage   = graybat::Cage<BMPI, GP, Serialization >;
-using ZMQConfig  = ZMQ::Config;
-using BMPIConfig = BMPI::Config;
-
-ZMQConfig zmqConfig = {"localhost:5000",
-                       "tcp://127.0.0.1:5001",
-                       static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
-					   "context_vertex_test"};
-
-BMPIConfig bmpiConfig;
-
-ZMQCage zmqCage(zmqConfig);
-BMPICage bmpiCage(bmpiConfig);
-
-auto cages = hana::make_tuple(std::ref(zmqCage),
-                              std::ref(bmpiCage) );
-
-/***************************************************************************
- * Test Cases
- ****************************************************************************/
-BOOST_AUTO_TEST_CASE( spread_collect ){
-    hana::for_each(cages, [](auto cageRef){
-	    // Test setup
-            using Cage    = typename decltype(cageRef)::type;
-            using GP      = typename Cage::GraphPolicy;
-	    using Event   = typename Cage::Event;
-	    using Vertex  = typename Cage::Vertex;
-
-	    // Test run
-	    {	
-    
-		std::vector<Event> events;
-                auto& grid = cageRef.get();
-
-		grid.setGraph(graybat::pattern::Grid<GP>(grid.getPeers().size(),
-                                                         grid.getPeers().size()));
-		
-		grid.distribute(graybat::mapping::Consecutive());
-    
-		const unsigned nElements = 10;
-		const unsigned testValue = 5;
-    
-		std::vector<unsigned> send(nElements, testValue);
-
-    
-		for(Vertex v : grid.getHostedVertices()){
-		    v.spread(send, events);
-        
-		}
-
-		for(Vertex v : grid.getHostedVertices()){
-		    std::vector<unsigned> recv(nElements * v.nInEdges(), 0);
-		    v.collect(recv);
-		    for(unsigned r: recv){
-			BOOST_CHECK_EQUAL(r, testValue);
-            
-		    }
-        
-		}
-
-		// Wait to finish events
-		for(unsigned i = 0; i < events.size(); ++i){
-		    events.back().wait();
-		    events.pop_back();
-		}
-
-	    }
-
-	});
-    
+namespace {
+auto cages = graybat::test::utils::getCages();
 }
 
+BOOST_AUTO_TEST_SUITE(VertexTests)
 
-BOOST_AUTO_TEST_CASE( accumulate ){
-    hana::for_each(cages, [](auto cageRef){
-	    // Test setup
-            using Cage    = typename decltype(cageRef)::type;
-            using GP      = typename Cage::GraphPolicy;            
-	    using Event   = typename Cage::Event;
-	    using Vertex  = typename Cage::Vertex;
+BOOST_AUTO_TEST_CASE(spread_collect)
+{
+    hana::for_each(cages, [](auto cageRef) {
+        // Test setup
+        using Cage = typename decltype(cageRef)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Event = typename Cage::Event;
+        using Vertex = typename Cage::Vertex;
 
-	    // Test run
-	    {	
-    
-		std::vector<Event> events;
-                auto& grid = cageRef.get();
-                
-		grid.setGraph(graybat::pattern::Grid<GP>(grid.getPeers().size(),
-                                                         grid.getPeers().size()));
-		
-		grid.distribute(graybat::mapping::Consecutive());
-    
-		const unsigned nElements = 1;
-		const unsigned testValue = 5;
-    
-		std::vector<unsigned> send(nElements, testValue);
+        // Test run
+        {
 
-    
-		for(Vertex v : grid.getHostedVertices()){
-		    v.spread(send, events);
-        
-		}
+            std::vector<Event> events;
+            auto& grid = *cageRef;
 
-		for(Vertex v : grid.getHostedVertices()){
-		    BOOST_CHECK_EQUAL(v.accumulate(std::plus<unsigned>(), 0),
-				      testValue * nElements * v.nInEdges());
-                
-		}
+            grid.setGraph(
+                graybat::pattern::Grid<GP>(grid.getPeers().size(), grid.getPeers().size()));
 
-		// Wait to finish events
-		for(unsigned i = 0; i < events.size(); ++i){
-		    events.back().wait();
-		    events.pop_back();
-		}
-    
-	    }
+            grid.distribute(graybat::mapping::Consecutive());
 
-	});
-    
+            const unsigned nElements = 10;
+            const unsigned testValue = 5;
+
+            std::vector<unsigned> send(nElements, testValue);
+
+            for (Vertex v : grid.getHostedVertices()) {
+                v.spread(send, events);
+            }
+
+            for (Vertex v : grid.getHostedVertices()) {
+                std::vector<unsigned> recv(nElements * v.nInEdges(), 0);
+                v.collect(recv);
+                for (unsigned r : recv) {
+                    BOOST_CHECK_EQUAL(r, testValue);
+                }
+            }
+
+            // Wait to finish events
+            for (unsigned i = 0; i < events.size(); ++i) {
+                events.back().wait();
+                events.pop_back();
+            }
+        }
+
+    });
 }
 
-BOOST_AUTO_TEST_CASE( forward ){
-    hana::for_each(cages, [](auto cageRef){
-	    // Test setup
-            using Cage    = typename decltype(cageRef)::type;
-            using GP      = typename Cage::GraphPolicy;            
-	    using Event   = typename Cage::Event;
-	    using Vertex  = typename Cage::Vertex;
+BOOST_AUTO_TEST_CASE(accumulate)
+{
+    hana::for_each(cages, [](auto cageRef) {
+        // Test setup
+        using Cage = typename decltype(cageRef)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Event = typename Cage::Event;
+        using Vertex = typename Cage::Vertex;
 
-	    // Test run
-	    {	
-    
-		std::vector<Event> events;
-                auto& chain = cageRef.get();
-                
-		chain.setGraph(graybat::pattern::Chain<GP>(chain.getPeers().size()));
-		chain.distribute(graybat::mapping::Consecutive());
-    
-		const unsigned nElements = 100;
-		const unsigned testValue = 1;
-    
-		std::vector<unsigned> input(nElements, testValue);
-		std::vector<unsigned> output(nElements, 0);
-		std::vector<unsigned> intermediate(nElements, 0);
+        // Test run
+        {
 
-		const Vertex entry = chain.getVertex(0);
-		const Vertex exit  = chain.getVertex(chain.getVertices().size()-1);
-    
-    
-		for(Vertex v : chain.getHostedVertices()){
+            std::vector<Event> events;
+            auto& grid = *cageRef;
 
-		    if(v == entry){
-			v.spread(input, events);
-            
-		    }
+            grid.setGraph(
+                graybat::pattern::Grid<GP>(grid.getPeers().size(), grid.getPeers().size()));
 
-		    if(v == exit){
-			v.collect(output);
-			for(unsigned u : output){
-			    if(chain.getVertices().size() == 1)
-				BOOST_CHECK_EQUAL(u, testValue);
-			    if(chain.getVertices().size() == 2)
-				BOOST_CHECK_EQUAL(u, testValue);
-			    if(chain.getVertices().size() > 2)
-				BOOST_CHECK_EQUAL(u, testValue + (1 * chain.getVertices().size() - 2));
-                    
-			}
-            
-		    }
+            grid.distribute(graybat::mapping::Consecutive());
 
-		    if(v != entry and v != exit){
-			v.forward(intermediate, [](std::vector<unsigned> &v)->void{for(unsigned &u : v){u++;}});
-            
-		    }
-            
-        
-		}
+            const unsigned nElements = 1;
+            const unsigned testValue = 5;
 
-		// Wait to finish events
-		for(unsigned i = 0; i < events.size(); ++i){
-		    events.back().wait();
-		    events.pop_back();
-		}
+            std::vector<unsigned> send(nElements, testValue);
 
-	    }
-	    
-	});
-    
+            for (Vertex v : grid.getHostedVertices()) {
+                v.spread(send, events);
+            }
+
+            for (Vertex v : grid.getHostedVertices()) {
+                BOOST_CHECK_EQUAL(
+                    v.accumulate(std::plus<unsigned>(), 0), testValue * nElements * v.nInEdges());
+            }
+
+            // Wait to finish events
+            for (unsigned i = 0; i < events.size(); ++i) {
+                events.back().wait();
+                events.pop_back();
+            }
+        }
+
+    });
 }
 
+BOOST_AUTO_TEST_CASE(forward)
+{
+    hana::for_each(cages, [](auto cageRef) {
+        // Test setup
+        using Cage = typename decltype(cageRef)::element_type;
+        using GP = typename Cage::GraphPolicy;
+        using Event = typename Cage::Event;
+        using Vertex = typename Cage::Vertex;
+
+        // Test run
+        {
+
+            std::vector<Event> events;
+            auto& chain = *cageRef;
+
+            chain.setGraph(graybat::pattern::Chain<GP>(chain.getPeers().size()));
+            chain.distribute(graybat::mapping::Consecutive());
+
+            const unsigned nElements = 100;
+            const unsigned testValue = 1;
+
+            std::vector<unsigned> input(nElements, testValue);
+            std::vector<unsigned> output(nElements, 0);
+            std::vector<unsigned> intermediate(nElements, 0);
+
+            const Vertex entry = chain.getVertex(0);
+            const Vertex exit = chain.getVertex(chain.getVertices().size() - 1);
+
+            for (Vertex v : chain.getHostedVertices()) {
+
+                if (v == entry) {
+                    v.spread(input, events);
+                }
+
+                if (v == exit) {
+                    v.collect(output);
+                    for (unsigned u : output) {
+                        if (chain.getVertices().size() == 1)
+                            BOOST_CHECK_EQUAL(u, testValue);
+                        if (chain.getVertices().size() == 2)
+                            BOOST_CHECK_EQUAL(u, testValue);
+                        if (chain.getVertices().size() > 2)
+                            BOOST_CHECK_EQUAL(u, testValue + (1 * chain.getVertices().size() - 2));
+                    }
+                }
+
+                if (v != entry and v != exit) {
+                    v.forward(intermediate, [](std::vector<unsigned>& v) -> void {
+                        for (unsigned& u : v) {
+                            u++;
+                        }
+                    });
+                }
+            }
+
+            // Wait to finish events
+            for (unsigned i = 0; i < events.size(); ++i) {
+                events.back().wait();
+                events.pop_back();
+            }
+        }
+
+    });
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2017 Erik Zenker
+ *
+ * This file is part of Graybat.
+ *
+ * Graybat is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graybat is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Graybat.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// STL
+#include <memory>
+
+// BOOST
+#include <boost/hana/concat.hpp>
+#include <boost/hana/for_each.hpp>
+#include <boost/hana/tuple.hpp>
+#include <boost/test/unit_test.hpp>
+
+// GRAYBAT
+#include <graybat/graybat.hpp>
+
+namespace graybat {
+namespace test {
+namespace utils {
+
+auto inline getCommunicationPolicies()
+{
+#ifdef graybat_ZMQ_CP_ENABLED
+    using ZMQ = graybat::communicationPolicy::ZMQ;
+    using ZMQConfig = ZMQ::Config;
+    ZMQConfig zmqConfig = { "localhost:5000",
+                            "tcp://127.0.0.1:5001",
+                            static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
+                            "context_cp_test" };
+    auto zmq = boost::hana::make_tuple(std::make_shared<ZMQ>(zmqConfig));
+#else
+    auto zmq = boost::hana::make_tuple();
+#endif
+
+#ifdef graybat_BMPI_CP_ENABLED
+    using BMPI = graybat::communicationPolicy::BMPI;
+    using BMPIConfig = BMPI::Config;
+    BMPIConfig bmpiConfig;
+    auto bmpi = boost::hana::make_tuple(std::make_shared<BMPI>(bmpiConfig));
+#else
+    auto bmpi = boost::hana::make_tuple();
+#endif
+    return boost::hana::concat(zmq, bmpi);
+}
+
+auto inline getCages()
+{
+    using Serialization = graybat::serializationPolicy::ByteCast;
+    using GP = graybat::graphPolicy::BGL<>;
+#ifdef graybat_ZMQ_CP_ENABLED
+    using ZMQ = graybat::communicationPolicy::ZMQ;
+    using ZMQConfig = ZMQ::Config;
+    using ZMQCage = graybat::Cage<ZMQ, GP, Serialization>;
+    ZMQConfig zmqConfig = { "localhost:5000",
+                            "tcp://127.0.0.1:5001",
+                            static_cast<size_t>(std::stoi(std::getenv("OMPI_COMM_WORLD_SIZE"))),
+                            "context_cp_test" };
+    auto zmqCage = boost::hana::make_tuple(std::make_shared<ZMQCage>(zmqConfig));
+#else
+    auto zmqCage = boost::hana::make_tuple();
+#endif
+
+#ifdef graybat_BMPI_CP_ENABLED
+    using BMPI = graybat::communicationPolicy::BMPI;
+    using BMPIConfig = BMPI::Config;
+    using BMPICage = graybat::Cage<BMPI, GP, Serialization>;
+    BMPIConfig bmpiConfig;
+    auto bmpiCage = boost::hana::make_tuple(std::make_shared<BMPICage>(bmpiConfig));
+#else
+    auto bmpiCage = boost::hana::make_tuple();
+#endif
+
+    return boost::hana::concat(zmqCage, bmpiCage);
+}
+}
+}
+}


### PR DESCRIPTION
The usage of graybat changed a little bit:

* You include graybat via the umbrella header: `#include <graybat/graybat.hpp>`
* graybat provides compile time definitions 
  * graybat_ZMQ_CP_ENABLED
  * graybat_BMPI_CP_ENABLED
* If the graybat cmake config finds ZMQ then the particular definition will be set (the same is true for mpi)
